### PR TITLE
CONDEC-293 add jQueryConDec global variable in CONDEC add-on

### DIFF
--- a/src/main/resources/js/jquery/jquery.js
+++ b/src/main/resources/js/jquery/jquery.js
@@ -9576,7 +9576,7 @@ jQuery.each( { Height: "height", Width: "width" }, function( name, type ) {
 
 // })();
 // Expose jQuery to the global object
-window.jQuery = window.$ = jQuery;
+window.jQueryConDec = jQuery;
 
 // Expose jQuery as an AMD module, but only for AMD loaders that
 // understand the issues with loading multiple versions of jQuery

--- a/src/main/resources/js/jstree/jstree.js
+++ b/src/main/resources/js/jstree/jstree.js
@@ -9,9 +9,28 @@
 		module.exports = factory(require('jquery'));
 	}
 	else {
-		factory(jQuery);
+        // TODO: remove DEBUG lines
+        console.log("jstree.js init")
+        console.log("$ ver")
+        console.log($.fn.jquery)
+        console.log("jQueryConDec ver")
+        console.log(jQueryConDec.fn.jquery)
+		factory(jQueryConDec);
 	}
 }(function ($, undefined) {
+
+    // TODO: remove DEBUG lines
+    console.log("factory function init")
+    
+    console.log("factory $ ver")
+    console.log($.fn.jquery)
+    
+    console.log("window.$ ver")
+    console.log(window.$.fn.jquery)
+    
+    console.log("window jQueryConDec ver")
+    console.log(window.jQueryConDec.fn.jquery)
+        
 	"use strict";
 /*!
  * jsTree 3.3.5

--- a/src/main/resources/js/view.context.menu.js
+++ b/src/main/resources/js/view.context.menu.js
@@ -20,7 +20,7 @@ var contextMenuCreateAction = {
 
 function getSelectedTreeViewerNode(position) {
 	var selector = position.reference.prevObject.selector;
-	return $("#jstree").jstree(true).get_node(selector);
+	return jQueryConDec("#jstree").jstree(true).get_node(selector);
 }
 
 function getSelectedTreeViewerNodeId(node) {
@@ -370,7 +370,7 @@ function changeKtTo(id,position,type){
 			// getTreeViewerWithoutRootElement(document.getElementById("Relevant").checked, function(core) {
 			// 	var indexOfNode = getArrayId(core.data,getSelectedTreeViewerNodeId(position));
 			// 	var url = getIconUrl(core,indexOfNode,type);
-			// 	 $("#jstree").jstree(true).set_icon(getSelectedTreeViewerNode(position),url);
+			// 	 jQueryConDec("#jstree").jstree(true).set_icon(getSelectedTreeViewerNode(position),url);
 			// });
 			var idOfUiElement = "ui"+id;
 			replaceTagsFromContent(idOfUiElement,type);
@@ -444,7 +444,7 @@ var contextMenuDeleteSentenceAction = {
 		var node = getSelectedTreeViewerNode(position);
 		var id = node.id;
 		setSentenceIrrelevant(id,function(core,node){
-			$("#jstree").jstree(true).set_icon($('#jstree').jstree(true).get_node(id),"https://player.fm/static/images/128pixel.png");
+			jQueryConDec("#jstree").jstree(true).set_icon(jQueryConDec("#jstree").jstree(true).get_node(id),"https://player.fm/static/images/128pixel.png");
 			if(!(document.getElementById("Relevant") == null)){
 				document.getElementById("ui"+id).getElementsByClassName("tag")[0].textContent="";
 				document.getElementById("ui"+id).getElementsByClassName("tag")[1].textContent="";

--- a/src/main/resources/js/view.decision.knowledge.page.js
+++ b/src/main/resources/js/view.decision.knowledge.page.js
@@ -43,7 +43,7 @@ function updateView(nodeId) {
 	} else {
 		selectNodeInTreeViewer(nodeId);
 	}
-	$('#jstree').on("select_node.jstree", function(error, tree) {
+	jQueryConDec("#jstree").on("select_node.jstree", function(error, tree) {
 		var node = tree.node.data;
 		buildTreant(node.key, true);
 	});

--- a/src/main/resources/js/view.tab.panel.js
+++ b/src/main/resources/js/view.tab.panel.js
@@ -69,7 +69,7 @@ function buildTreeViewer2(showRelevant) {
 	console.log(jQuery.fn.jquery);
 
 	getTreeViewerWithoutRootElement(showRelevant, function(core) {
-		$("#jstree").jstree({
+		jQueryConDec("#jstree").jstree({
 			"core" : core,
 			"plugins" : [ "dnd", "contextmenu", "wholerow", "search","sort","state"],
 			"search" : {
@@ -82,7 +82,7 @@ function buildTreeViewer2(showRelevant) {
 			});
 		$("#jstree-search-input").keyup(function() {
 			var searchString = $(this).val();
-			$("#jstree").jstree(true).search(searchString);
+			jQueryConDec("#jstree").jstree(true).search(searchString);
 		});
 	});
 	addDragAndDropSupportForTreeViewer();

--- a/src/main/resources/js/view.tree.viewer.js
+++ b/src/main/resources/js/view.tree.viewer.js
@@ -2,7 +2,7 @@ function buildTreeViewer() {
 	resetTreeViewer();
 	var rootElementType = $("select[name='select-root-element-type']").val();
 	getTreeViewer(rootElementType, function(core) {
-		$("#jstree").jstree({
+		jQueryConDec("#jstree").jstree({
 			"core" : core,
 			"plugins" : [ "dnd", "contextmenu", "wholerow", "sort", "search","state" ],
 			"search" : {
@@ -14,7 +14,7 @@ function buildTreeViewer() {
 		});
 		$("#jstree-search-input").keyup(function() {
 			var searchString = $(this).val();
-			$("#jstree").jstree(true).search(searchString);
+			jQueryConDec("#jstree").jstree(true).search(searchString);
 		});
 	});
 	addDragAndDropSupportForTreeViewer();
@@ -29,7 +29,7 @@ function customMenu(node) {
 }
 
 function resetTreeViewer() {
-	var treeViewer = $("#jstree").jstree(true);
+	var treeViewer = jQueryConDec("#jstree").jstree(true);
 	if (treeViewer) {
 		treeViewer.destroy();
 	}
@@ -39,12 +39,12 @@ function getTreeViewerNodeById(nodeId) {
 	if (nodeId === "#") {
 		return nodeId;
 	}
-	return $("#jstree").jstree(true).get_node(nodeId);
+	return jQueryConDec("#jstree").jstree(true).get_node(nodeId);
 }
 
 function selectNodeInTreeViewer(nodeId) {
-	$("#jstree").on("ready.jstree", function() {
-		var treeViewer = $("#jstree").jstree(true);
+	jQueryConDec("#jstree").on("ready.jstree", function() {
+		var treeViewer = jQueryConDec("#jstree").jstree(true);
 		if (treeViewer) {
 			treeViewer.select_node(nodeId);
 		}
@@ -52,7 +52,7 @@ function selectNodeInTreeViewer(nodeId) {
 }
 
 function addDragAndDropSupportForTreeViewer() {
-	$("#jstree").on('move_node.jstree', function(object, nodeInContext) {
+	jQueryConDec("#jstree").on('move_node.jstree', function(object, nodeInContext) {
 		var node = nodeInContext.node;
 		var parentNode = getTreeViewerNodeById(nodeInContext.parent);
 		var oldParentNode = getTreeViewerNodeById(nodeInContext.old_parent);


### PR DESCRIPTION
* hacks the line exporting to global scope for add-on's 1.9.1 jquery.js
* replace $ usage in all add-on's javascript files controlling the views, when jstree is expected