### PR TITLE
Condec 339.restructure.tojavascript.objects

### DIFF
--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/extraction/view/DecisionKnowledgeReport.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/extraction/view/DecisionKnowledgeReport.java
@@ -72,7 +72,7 @@ public class DecisionKnowledgeReport extends AbstractReport {
 		// get Number of relevant Sentences per Issue
 		Map<String, Integer> numRelevantSentences = getNumberOfRelevantSentences(action.getLoggedInUser());
 		velocityParams.put("numRelevantSentences", numRelevantSentences);
-		velocityParams.put("map", Map.class);
+		velocityParams.put("map", Map.class); // TODO: what was this for? It is not used in vm.
 
 		// get Number of commits per Issue
 		List<Integer> numCommitsPerIssue = getNumberOfCommitsPerIssue(action.getLoggedInUser());

--- a/src/main/resources/js/management.js
+++ b/src/main/resources/js/management.js
@@ -11,10 +11,10 @@ var knowledgeTypes = getKnowledgeTypes(getProjectKey());
 var defaultKnowledgeTypes = getDefaultKnowledgeTypes(getProjectKey());
 var extendedKnowledgeTypes = replaceArgumentWithLinkTypes(knowledgeTypes);
 
-function replaceArgumentWithLinkTypes(knowledgeTypes) {
-	console.log("management.js replaceArgumentWithLinkTypes");
+function replaceArgumentWithLinkTypes(knowledgeTypes) { // TODO: check why is/was knowledgeTypes passed?
+    console.log("management.js replaceArgumentWithLinkTypes");
 	var extendedKnowledgeTypes = getKnowledgeTypes(getProjectKey());
-	remove(extendedKnowledgeTypes, "Argument");
+	extendedKnowledgeTypes = extendedKnowledgeTypes.filter( function(value) { return value.toLowerCase() !== "argument";} );
 	extendedKnowledgeTypes.push("Pro-argument");
 	extendedKnowledgeTypes.push("Con-argument");
 	return extendedKnowledgeTypes;
@@ -132,18 +132,6 @@ function showFlag(type, message) {
 		title : type.charAt(0).toUpperCase() + type.slice(1),
 		body : message
 	});
-}
-
-/*
- * TODO refactor name or extend array prototype or wehere use replace with arrow
- * function...
- */
-function remove(array, item) {
-	for (var i = array.length; i--;) {
-		if (array[i] === item) {
-			array.splice(i, 1);
-		}
-	}
 }
 
 function getURLsSearch() {

--- a/src/main/resources/js/management.js
+++ b/src/main/resources/js/management.js
@@ -3,17 +3,17 @@
  * "Assumption", "Claim", "Constraint", "Context", "Decision",
  * "Goal", "Implication", "Issue", "Problem", and "Solution".
  */
-var knowledgeTypes = getKnowledgeTypes(getProjectKey());
+var knowledgeTypes = conDecAPI.getKnowledgeTypes(getProjectKey());
 /*
  * Default knowledge types are "Alternative", "Argument", "Decision", and
  * "Issue".
  */
-var defaultKnowledgeTypes = getDefaultKnowledgeTypes(getProjectKey());
+var defaultKnowledgeTypes = conDecAPI.getDefaultKnowledgeTypes(getProjectKey());
 var extendedKnowledgeTypes = replaceArgumentWithLinkTypes(knowledgeTypes);
 
 function replaceArgumentWithLinkTypes(knowledgeTypes) { // TODO: check why is/was knowledgeTypes passed?
     console.log("management.js replaceArgumentWithLinkTypes");
-	var extendedKnowledgeTypes = getKnowledgeTypes(getProjectKey());
+	var extendedKnowledgeTypes = conDecAPI.getKnowledgeTypes(getProjectKey());
 	extendedKnowledgeTypes = extendedKnowledgeTypes.filter( function(value) { return value.toLowerCase() !== "argument";} );
 	extendedKnowledgeTypes.push("Pro-argument");
 	extendedKnowledgeTypes.push("Con-argument");
@@ -48,7 +48,7 @@ function updateDecisionKnowledgeElementAsChild(childId, summary, description, ty
 	console.log("management.js updateDecisionKnowledgeElementAsChild");
 	var simpleType = getSimpleType(type);
 	updateDecisionKnowledgeElement(childId, summary, description, simpleType, function() {
-		getDecisionKnowledgeElement(childId, function(decisionKnowledgeElement) {
+		conDecAPI.getDecisionKnowledgeElement(childId, function(decisionKnowledgeElement) {
 			if (decisionKnowledgeElement.type !== type) {
 				var parentId = findParentId(childId);
 				switchLinkTypes(type, parentId, childId, function(linkType, parentId, childId) {
@@ -77,10 +77,10 @@ function getSimpleType(type) {
 function createDecisionKnowledgeElementAsChild(summary, description, type, idOfExistingElement) {
 	console.log("management.js createDecisionKnowledgeElementAsChild");
 	var simpleType = getSimpleType(type);
-	createDecisionKnowledgeElement(summary, description, simpleType, function(idOfNewElement) {
+	conDecAPI.createDecisionKnowledgeElement(summary, description, simpleType, function(idOfNewElement) {
 		switchLinkTypes(type, idOfExistingElement, idOfNewElement, function(linkType, idOfExistingElement,
 				idOfNewElement) {
-			linkElements(idOfExistingElement, idOfNewElement, linkType, function() {
+			conDecAPI.linkElements(idOfExistingElement, idOfNewElement, linkType, function() {
 				updateView();
 			});
 		});

--- a/src/main/resources/js/rest.client.js
+++ b/src/main/resources/js/rest.client.js
@@ -1,668 +1,847 @@
-function getJSON(url, callback) {
-	var xhr = new XMLHttpRequest();
-	xhr.open("GET", url, true);
-	xhr.setRequestHeader("Content-type", "application/json; charset=utf-8");
-	xhr.responseType = "json";
-	xhr.onload = function() {
-		var status = xhr.status;
-		if (status === 200) {
-			callback(null, xhr.response);
-		} else {
-			callback(status);
-		}
-	};
-	xhr.send();
-}
+/*
+ This module implements communication with the ConDec Java REST API
+ 
+ As known on 02. November 2018 this module:
+ 
+ Requires
+ * mangament.global.getProjectKey()
+    
+ Is required by
+ * view.*
+  
+  
+ Is referenced in HTML by
+ * settingsForAllProjects.vm and settingsForSingleProject.vm
+ 
+*/
 
-function getResponseAsReturnValue(url) {
-	var xhr = new XMLHttpRequest();
-	xhr.open("GET", url, false);
-	xhr.setRequestHeader("Content-type", "application/json; charset=utf-8");
-	xhr.send();
-	return JSON.parse(xhr.response);
-}
+(function (global) {
+    
+    var ConDecAPI = function ConDecAPI() {        
+    }
+    
+    /*
+     external references: none, only within this closure.
+    */
+    function getJSON(url, callback) {
+        var xhr = new XMLHttpRequest();
+        xhr.open("GET", url, true);
+        xhr.setRequestHeader("Content-type", "application/json; charset=utf-8");
+        xhr.responseType = "json";
+        xhr.onload = function() {
+            var status = xhr.status;
+            if (status === 200) {
+                callback(null, xhr.response);
+            } else {
+                callback(status);
+            }
+        };
+        xhr.send();
+    }
 
-function postWithResponseAsReturnValue(url) {
-	var xhr = new XMLHttpRequest();
-	xhr.open("POST", url, false);
-	xhr.setRequestHeader("Content-type", "application/json; charset=utf-8");
-	xhr.send();
-	return JSON.parse(xhr.response);
-}
+    /*
+     external references: none, only within this closure.
+    */
+    function getResponseAsReturnValue(url) {
+        var xhr = new XMLHttpRequest();
+        xhr.open("GET", url, false);
+        xhr.setRequestHeader("Content-type", "application/json; charset=utf-8");
+        xhr.send();
+        return JSON.parse(xhr.response);
+    }
 
-function postJSON(url, data, callback) {
-	var xhr = new XMLHttpRequest();
-	xhr.open("POST", url, true);
-	xhr.setRequestHeader("Content-type", "application/json; charset=utf-8");
-	xhr.setRequestHeader("Accept", "application/json");
-	xhr.responseType = "json";
-	xhr.onload = function() {
-		var status = xhr.status;
-		if (status === 200) {
-			callback(null, xhr.response);
-		} else {
-			callback(status);
-		}
-	};
-	xhr.send(JSON.stringify(data));
-}
+    /*
+     external references: none, only within this closure.
+    */
+    function postWithResponseAsReturnValue(url) {
+        var xhr = new XMLHttpRequest();
+        xhr.open("POST", url, false);
+        xhr.setRequestHeader("Content-type", "application/json; charset=utf-8");
+        xhr.send();
+        return JSON.parse(xhr.response);
+    }
 
-function putJSON(url, data, callback) {
-	var xhr = new XMLHttpRequest();
-	xhr.open("PUT", url, true);
-	xhr.setRequestHeader("Content-type", "application/json; charset=utf-8");
-	xhr.setRequestHeader("Accept", "application/json");
-	xhr.responseType = "json";
-	xhr.onload = function() {
-		var status = xhr.status;
-		if (status === 200) {
-			callback(null, xhr.response);
-		} else {
-			callback(status);
-		}
-	};
-	xhr.send(JSON.stringify(data));
-}
+    /*
+     external references: none, only within this closure.
+    */
+    function postJSON(url, data, callback) {
+        var xhr = new XMLHttpRequest();
+        xhr.open("POST", url, true);
+        xhr.setRequestHeader("Content-type", "application/json; charset=utf-8");
+        xhr.setRequestHeader("Accept", "application/json");
+        xhr.responseType = "json";
+        xhr.onload = function() {
+            var status = xhr.status;
+            if (status === 200) {
+                callback(null, xhr.response);
+            } else {
+                callback(status);
+            }
+        };
+        xhr.send(JSON.stringify(data));
+    }
 
-function deleteJSON(url, data, callback) {
-	var xhr = new XMLHttpRequest();
-	xhr.open("DELETE", url, true);
-	xhr.setRequestHeader("Content-type", "application/json; charset=utf-8");
-	xhr.setRequestHeader("Accept", "application/json");
-	xhr.responseType = "json";
-	xhr.onload = function() {
-		var status = xhr.status;
-		if (status === 200) {
-			callback(null, xhr.response);
-		} else {
-			callback(status);
-		}
-	};
-	xhr.send(JSON.stringify(data));
-}
+    /*
+     external references: none, only within this closure.
+    */
+    function putJSON(url, data, callback) {
+        var xhr = new XMLHttpRequest();
+        xhr.open("PUT", url, true);
+        xhr.setRequestHeader("Content-type", "application/json; charset=utf-8");
+        xhr.setRequestHeader("Accept", "application/json");
+        xhr.responseType = "json";
+        xhr.onload = function() {
+            var status = xhr.status;
+            if (status === 200) {
+                callback(null, xhr.response);
+            } else {
+                callback(status);
+            }
+        };
+        xhr.send(JSON.stringify(data));
+    }
 
-function getDecisionKnowledgeElement(id, callback) {
-	getJSON(
-			AJS.contextPath() + "/rest/decisions/latest/decisions/getDecisionKnowledgeElement.json?projectKey="
-					+ getProjectKey() + "&id=" + id,
-			function(error, decisionKnowledgeElement) {
-				if (error === null) {
-					callback(decisionKnowledgeElement);
-				} else {
-					showFlag("error",
-							"An error occured when receiving the decision knowledge element for the given id and project key.");
-				}
-			});
-}
+    /*
+     external references: none, only within this closure.
+    */
+    function deleteJSON(url, data, callback) {
+        var xhr = new XMLHttpRequest();
+        xhr.open("DELETE", url, true);
+        xhr.setRequestHeader("Content-type", "application/json; charset=utf-8");
+        xhr.setRequestHeader("Accept", "application/json");
+        xhr.responseType = "json";
+        xhr.onload = function() {
+            var status = xhr.status;
+            if (status === 200) {
+                callback(null, xhr.response);
+            } else {
+                callback(status);
+            }
+        };
+        xhr.send(JSON.stringify(data));
+    }
 
-function getLinkedElements(id, callback) {
-	getJSON(
-			AJS.contextPath() + "/rest/decisions/latest/decisions/getLinkedElements.json?projectKey=" + getProjectKey()
-					+ "&id=" + id,
-			function(error, linkedElements) {
-				if (error === null) {
-					callback(linkedElements);
-				} else {
-					showFlag("error",
-							"An error occured when receiving the linked decision knowledge elements for the selected element.");
-				}
-			});
-}
+    /*
+     external references: management, view.context.menu, view.decision.knowledge.page, view.issue.module ..
+    */
+    ConDecAPI.prototype.getDecisionKnowledgeElement = function getDecisionKnowledgeElement(id, callback) {
+        getJSON(
+                AJS.contextPath() + "/rest/decisions/latest/decisions/getDecisionKnowledgeElement.json?projectKey="
+                        + global.getProjectKey() + "&id=" + id,
+                function(error, decisionKnowledgeElement) {
+                    if (error === null) {
+                        callback(decisionKnowledgeElement);
+                    } else {
+                        showFlag("error",
+                                "An error occured when receiving the decision knowledge element for the given id and project key.");
+                    }
+                });
+    }
 
-function getUnlinkedElements(id, callback) {
-	getJSON(
-			AJS.contextPath() + "/rest/decisions/latest/decisions/getUnlinkedElements.json?projectKey="
-					+ getProjectKey() + "&id=" + id,
-			function(error, unlinkedElements) {
-				if (error === null) {
-					callback(unlinkedElements);
-				} else {
-					showFlag("error",
-							"An error occured when receiving the unlinked decision knowledge elements for the selected element.");
-				}
-			});
-}
+    /*
+     external references: view.issue.module ..
+    */
+    ConDecAPI.prototype.getLinkedElements = function getLinkedElements(id, callback) {
+        getJSON(
+                AJS.contextPath() + "/rest/decisions/latest/decisions/getLinkedElements.json?projectKey=" + global.getProjectKey()
+                        + "&id=" + id,
+                function(error, linkedElements) {
+                    if (error === null) {
+                        callback(linkedElements);
+                    } else {
+                        showFlag("error",
+                                "An error occured when receiving the linked decision knowledge elements for the selected element.");
+                    }
+                });
+    }
 
-function createDecisionKnowledgeElement(summary, description, type, callback) {
-	if (summary !== "") {
-		var jsondata = {
-			"projectKey" : getProjectKey(),
-			"summary" : summary,
-			"type" : type,
-			"description" : description
-		};
-		postJSON(AJS.contextPath() + "/rest/decisions/latest/decisions/createDecisionKnowledgeElement.json", jsondata,
-				function(error, decisionKnowledgeElement) {
-					if (error === null) {
-						showFlag("success", type + " has been created.");
-						callback(decisionKnowledgeElement.id);
-					} else {
-						showFlag("error", type + " has not been created. Error Code: " + error);
-					}
-				});
-	}
-}
+    /*
+     external references: view.context.menu ..
+    */
+    ConDecAPI.prototype.getUnlinkedElements = function getUnlinkedElements(id, callback) {
+        getJSON(
+                AJS.contextPath() + "/rest/decisions/latest/decisions/getUnlinkedElements.json?projectKey="
+                        + global.getProjectKey() + "&id=" + id,
+                function(error, unlinkedElements) {
+                    if (error === null) {
+                        callback(unlinkedElements);
+                    } else {
+                        showFlag("error",
+                                "An error occured when receiving the unlinked decision knowledge elements for the selected element.");
+                    }
+                });
+    }
 
-function updateDecisionKnowledgeElement(id, summary, description, type, callback) {
-	var jsondata = {
-		"id" : id,
-		"summary" : summary,
-		"type" : type,
-		"projectKey" : getProjectKey(),
-		"description" : description
-	};
-	postJSON(AJS.contextPath() + "/rest/decisions/latest/decisions/updateDecisionKnowledgeElement.json", jsondata,
-			function(error, decisionKnowledgeElement) {
-				if (error === null) {
-					showFlag("success", "Decision knowledge element has been updated.");
-					callback(decisionKnowledgeElement);
-				} else {
-					showFlag("error", "Decision knowledge element was not updated. Error Code: " + error);
-				}
-			});
-}
+    /*
+     external references: management, view.issue.module, view.decision.knowledge.page ..
+    */
+    ConDecAPI.prototype.createDecisionKnowledgeElement = function createDecisionKnowledgeElement(summary, description, type, callback) {
+        if (summary !== "") {
+            var jsondata = {
+                "projectKey" : global.getProjectKey(),
+                "summary" : summary,
+                "type" : type,
+                "description" : description
+            };
+            postJSON(AJS.contextPath() + "/rest/decisions/latest/decisions/createDecisionKnowledgeElement.json", jsondata,
+                    function(error, decisionKnowledgeElement) {
+                        if (error === null) {
+                            showFlag("success", type + " has been created.");
+                            callback(decisionKnowledgeElement.id);
+                        } else {
+                            showFlag("error", type + " has not been created. Error Code: " + error);
+                        }
+                    });
+        }
+    }
 
-function deleteDecisionKnowledgeElement(id, callback) {
-	var jsondata = {
-		"id" : id,
-		"projectKey" : getProjectKey()
-	};
-	deleteJSON(AJS.contextPath() + "/rest/decisions/latest/decisions/deleteDecisionKnowledgeElement.json", jsondata,
-			function(error, isDeleted) {
-				if (error === null) {
-					showFlag("success", "Decision knowledge element has been deleted.");
-					callback();
-				} else {
-					showFlag("error", "Decision knowledge element was not deleted. Error Code: " + error);
-				}
-			});
-}
+    /*
+     external references: management ..
+    */
+    ConDecAPI.prototype.updateDecisionKnowledgeElement = function updateDecisionKnowledgeElement(id, summary, description, type, callback) {
+        var jsondata = {
+            "id" : id,
+            "summary" : summary,
+            "type" : type,
+            "projectKey" : global.getProjectKey(),
+            "description" : description
+        };
+        postJSON(AJS.contextPath() + "/rest/decisions/latest/decisions/updateDecisionKnowledgeElement.json", jsondata,
+                function(error, decisionKnowledgeElement) {
+                    if (error === null) {
+                        showFlag("success", "Decision knowledge element has been updated.");
+                        callback(decisionKnowledgeElement);
+                    } else {
+                        showFlag("error", "Decision knowledge element was not updated. Error Code: " + error);
+                    }
+                });
+    }
 
-function linkElements(idOfDestinationElement, idOfSourceElement, linkType, callback) {
-	var jsondata = {
-		"type" : linkType,
-		"idOfSourceElement" : idOfSourceElement,
-		"idOfDestinationElement" : idOfDestinationElement
-	};
-	postJSON(AJS.contextPath() + "/rest/decisions/latest/decisions/createLink.json?projectKey=" + getProjectKey(),
-			jsondata, function(error, link) {
-				if (error === null) {
-					showFlag("success", "Link has been created.");
-					callback(link);
-				} else {
-					showFlag("error", "Link could not be created.");
-				}
-			});
-}
 
-function deleteLink(idOfDestinationElement, idOfSourceElement, callback) {
-	var jsondata = {
-		"idOfSourceElement" : idOfSourceElement,
-		"idOfDestinationElement" : idOfDestinationElement
-	};
-	deleteJSON(AJS.contextPath() + "/rest/decisions/latest/decisions/deleteLink.json?projectKey=" + getProjectKey(),
-			jsondata, function(error, link) {
-				if (error === null) {
-					showFlag("success", "Link has been deleted.");
-					callback();
-				} else {
-					showFlag("error", "Link could not be deleted.");
-				}
+    /*
+     external references: view.context.menu ..
+    */
+    ConDecAPI.prototype.deleteDecisionKnowledgeElement = function deleteDecisionKnowledgeElement(id, callback) {
+        var jsondata = {
+            "id" : id,
+            "projectKey" : global.getProjectKey()
+        };
+        deleteJSON(AJS.contextPath() + "/rest/decisions/latest/decisions/deleteDecisionKnowledgeElement.json", jsondata,
+                function(error, isDeleted) {
+                    if (error === null) {
+                        showFlag("success", "Decision knowledge element has been deleted.");
+                        callback();
+                    } else {
+                        showFlag("error", "Decision knowledge element was not deleted. Error Code: " + error);
+                    }
+                });
+    }
 
-			});
-}
+    /*
+     external references: management ..
+    */
+    ConDecAPI.prototype.linkElements = function linkElements(idOfDestinationElement, idOfSourceElement, linkType, callback) {
+        var jsondata = {
+            "type" : linkType,
+            "idOfSourceElement" : idOfSourceElement,
+            "idOfDestinationElement" : idOfDestinationElement
+        };
+        postJSON(AJS.contextPath() + "/rest/decisions/latest/decisions/createLink.json?projectKey=" + global.getProjectKey(),
+                jsondata, function(error, link) {
+                    if (error === null) {
+                        showFlag("success", "Link has been created.");
+                        callback(link);
+                    } else {
+                        showFlag("error", "Link could not be created.");
+                    }
+                });
+    }
 
-function deleteSentenceLink(idOfDestinationElement, idOfSourceElement, callback) {
-	var jsondata = {
-		"idOfSourceElement" : idOfSourceElement,
-		"idOfDestinationElement" : idOfDestinationElement
-	};
-	deleteJSON(AJS.contextPath() + "/rest/decisions/latest/decisions/deleteLinkBetweenSentences.json?projectKey="
-			+ getProjectKey(), jsondata, function(error, link) {
-		if (error === null) {
-			showFlag("success", "Link has been deleted.");
-			callback();
-		} else {
-			showFlag("error", "Link could not be deleted.");
-		}
+    /*
+     external references: management, view.context.menu, view.decision.knowledge.page, view.issue.module, view.treant, view.tree.viewer ..
+    */
+    ConDecAPI.prototype.deleteLink = function deleteLink(idOfDestinationElement, idOfSourceElement, callback) {
+        var jsondata = {
+            "idOfSourceElement" : idOfSourceElement,
+            "idOfDestinationElement" : idOfDestinationElement
+        };
+        deleteJSON(AJS.contextPath() + "/rest/decisions/latest/decisions/deleteLink.json?projectKey=" + global.getProjectKey(),
+                jsondata, function(error, link) {
+                    if (error === null) {
+                        showFlag("success", "Link has been deleted.");
+                        callback();
+                    } else {
+                        showFlag("error", "Link could not be deleted.");
+                    }
 
-	});
-}
+                });
+    }
 
-function setSentenceIrrelevant(id, callback) {
-	var jsondata = {
-		"id" : id,
-		"summary" : "",
-		"type" : "",
-		"projectKey" : "",
-		"description" : ""
-	};
-	postJSON(AJS.contextPath() + "/rest/decisions/latest/decisions/setSentenceIrrelevant.json", jsondata, function(
-			error) {
-		if (error === null) {
-			showFlag("success", "Decision knowledge element has been updated.");
-			callback();
-		} else {
-			showFlag("error", "Decision knowledge element was not updated. Error Code: " + error);
-		}
-	});
-}
 
-function changeKnowledgeTypeOfSentence(id, type, callback) {
-	var jsondata = {
-		"id" : id,
-		"type" : type
-	};
-	var argument = "";// Important to be empty!
-	if (type.includes("Pro") || type.includes("Con")) {
-		argument = type;
-	}
-	postJSON(AJS.contextPath() + "/rest/decisions/latest/decisions/changeKnowledgeTypeOfSentence.json?projectKey="
-			+ getProjectKey() + "&argument=" + argument, jsondata, function(error, link) {
-		if (error === null) {
-			showFlag("success", "Knowledge type has been changed.");
-			callback(link);
-		} else {
-			showFlag("error", "Knowledge type could not be changed.");
-		}
-	});
-}
+    /*
+     external references: none, not even used locally! //TODO: delete function?
+    */
+    ConDecAPI.prototype.deleteSentenceLink = function deleteSentenceLink(idOfDestinationElement, idOfSourceElement, callback) {
+        var jsondata = {
+            "idOfSourceElement" : idOfSourceElement,
+            "idOfDestinationElement" : idOfDestinationElement
+        };
+        deleteJSON(AJS.contextPath() + "/rest/decisions/latest/decisions/deleteLinkBetweenSentences.json?projectKey="
+                + global.getProjectKey(), jsondata, function(error, link) {
+            if (error === null) {
+                showFlag("success", "Link has been deleted.");
+                callback();
+            } else {
+                showFlag("error", "Link could not be deleted.");
+            }
 
-function editSentenceBody(id, body, type, callback) {
-	var jsondata = {
-		"id" : id,
-		"summary" : "",
-		"type" : type,
-		"projectKey" : getProjectKey(),
-		"description" : body
-	};
-	postJSON(AJS.contextPath() + "/rest/decisions/latest/decisions/editSentenceBody.json?argument=" + type, jsondata,
-			function(error, id, type) {
-				if (error === null) {
-					showFlag("success", "Decision knowledge element has been updated.");
-					callback(id, type);
-				} else {
-					showFlag("error", "Decision knowledge element was not updated. Error Code: " + error);
-				}
-			});
-}
+        });
+    }
 
-function deleteGenericLink(targetId, sourceId, targetType, sourceType, callback, showError) {
-	var jsondata = {
-		"idOfSourceElement" : sourceType + sourceId,
-		"idOfDestinationElement" : targetType + targetId
-	};
-	deleteJSON(AJS.contextPath() + "/rest/decisions/latest/decisions/deleteGenericLink.json?projectKey="
-			+ getProjectKey(), jsondata, function(error, link) {
-		if (error === null) {
-			showFlag("success", "Link has been deleted.");
-			callback();
-		} else if (showError) {
-			showFlag("error", "Link could not be deleted.");
-		}
+    /*
+     external references: view.context.menu
+    */
+    ConDecAPI.prototype.setSentenceIrrelevant = function setSentenceIrrelevant(id, callback) {
+        var jsondata = {
+            "id" : id,
+            "summary" : "",
+            "type" : "",
+            "projectKey" : "",
+            "description" : ""
+        };
+        postJSON(AJS.contextPath() + "/rest/decisions/latest/decisions/setSentenceIrrelevant.json", jsondata, function(
+                error) {
+            if (error === null) {
+                showFlag("success", "Decision knowledge element has been updated.");
+                callback();
+            } else {
+                showFlag("error", "Decision knowledge element was not updated. Error Code: " + error);
+            }
+        });
+    }
 
-	});
-}
+    /*
+     external references: view.context.menu 
+    */
+    ConDecAPI.prototype.changeKnowledgeTypeOfSentence = function changeKnowledgeTypeOfSentence(id, type, callback) {
+        var jsondata = {
+            "id" : id,
+            "type" : type
+        };
+        var argument = "";// Important to be empty!
+        if (type.includes("Pro") || type.includes("Con")) {
+            argument = type;
+        }
+        postJSON(AJS.contextPath() + "/rest/decisions/latest/decisions/changeKnowledgeTypeOfSentence.json?projectKey="
+                + global.getProjectKey() + "&argument=" + argument, jsondata, function(error, link) {
+            if (error === null) {
+                showFlag("success", "Knowledge type has been changed.");
+                callback(link);
+            } else {
+                showFlag("error", "Knowledge type could not be changed.");
+            }
+        });
+    }
 
-function linkGenericElements(targetId, sourceId, targetType, sourceType, callback) {
-	var jsondata = {
-		"type" : "contain",
-		"idOfSourceElement" : sourceType + sourceId,
-		"idOfDestinationElement" : targetType + targetId
-	};
-	postJSON(AJS.contextPath() + "/rest/decisions/latest/decisions/createGenericLink.json?projectKey="
-			+ getProjectKey(), jsondata, function(error, link) {
-		if (error === null) {
-			showFlag("success", "Link has been created.");
-			callback(link);
-		} else {
-			showFlag("error", "Link could not be created.");
-		}
-	});
-}
+    /*
+     external references: view.context.menu ..
+    */
+    ConDecAPI.prototype.editSentenceBody = function editSentenceBody(id, body, type, callback) {
+        var jsondata = {
+            "id" : id,
+            "summary" : "",
+            "type" : type,
+            "projectKey" : global.getProjectKey(),
+            "description" : body
+        };
+        postJSON(AJS.contextPath() + "/rest/decisions/latest/decisions/editSentenceBody.json?argument=" + type, jsondata,
+                function(error, id, type) {
+                    if (error === null) {
+                        showFlag("success", "Decision knowledge element has been updated.");
+                        callback(id, type);
+                    } else {
+                        showFlag("error", "Decision knowledge element was not updated. Error Code: " + error);
+                    }
+                });
+    }
 
-function getTreeViewer(rootElementType, callback) {
-	getJSON(AJS.contextPath() + "/rest/decisions/latest/view/getTreeViewer.json?projectKey=" + getProjectKey()
-			+ "&rootElementType=" + rootElementType, function(error, core) {
-		if (error === null) {
-			callback(core);
-		} else {
-			showFlag("error", "Tree viewer data could not be received. Error-Code: " + error);
-		}
-	});
-}
+    /*
+     external references: view.context.menu, view.treant, view.tree.viewer ..
+    */
+    ConDecAPI.prototype.deleteGenericLink = function deleteGenericLink(targetId, sourceId, targetType, sourceType, callback, showError) {
+        var jsondata = {
+            "idOfSourceElement" : sourceType + sourceId,
+            "idOfDestinationElement" : targetType + targetId
+        };
+        deleteJSON(AJS.contextPath() + "/rest/decisions/latest/decisions/deleteGenericLink.json?projectKey="
+                + global.getProjectKey(), jsondata, function(error, link) {
+            if (error === null) {
+                showFlag("success", "Link has been deleted.");
+                callback();
+            } else if (showError) {
+                showFlag("error", "Link could not be deleted.");
+            }
 
-function getTreant(elementKey, depthOfTree, searchTerm, callback) {
-	getJSON(AJS.contextPath() + "/rest/decisions/latest/view/getTreant.json?&elementKey=" + elementKey
-			+ "&depthOfTree=" + depthOfTree + "&searchTerm=" + searchTerm, function(error, treant) {
-		if (error === null) {
-			callback(treant);
-		} else {
-			showFlag("error", "Filtered Treant data could not be received. Error-Code: " + error);
-		}
-	});
-}
+        });
+    }
 
-function getTreeViewerWithoutRootElement(showRelevant, callback) {
-	var issueId = AJS.$("meta[name='ajs-issue-key']").attr("content");
-	if (issueId === undefined) {
-		issueId = getIssueKey();
-	}
-	getJSON(AJS.contextPath() + "/rest/decisions/latest/view/getTreeViewer2.json?issueKey=" + issueId
-			+ "&showRelevant=" + showRelevant, function(error, core) {
-		if (error === null) {
-			callback(core);
-		} else {
-			showFlag("error", "Tree viewer data could not be received. Error-Code: " + error);
-		}
-	});
-}
+    /*
+     external references: view.treant, view.tree.viewer ..
+    */
+    ConDecAPI.prototype.linkGenericElements = function linkGenericElements(targetId, sourceId, targetType, sourceType, callback) {
+        var jsondata = {
+            "type" : "contain",
+            "idOfSourceElement" : sourceType + sourceId,
+            "idOfDestinationElement" : targetType + targetId
+        };
+        postJSON(AJS.contextPath() + "/rest/decisions/latest/decisions/createGenericLink.json?projectKey="
+                + global.getProjectKey(), jsondata, function(error, link) {
+            if (error === null) {
+                showFlag("success", "Link has been created.");
+                callback(link);
+            } else {
+                showFlag("error", "Link could not be created.");
+            }
+        });
+    }
 
-function setActivated(isActivated, projectKey) {
-	postJSON(AJS.contextPath() + "/rest/decisions/latest/config/setActivated.json?projectKey=" + projectKey
-			+ "&isActivated=" + isActivated, null, function(error, response) {
-		if (error === null) {
-			showFlag("success", "Plug-in activation for the project has been set to " + isActivated + ".");
-		} else {
-			showFlag("error", "Plug-in activation for the project has not been changed.");
-		}
-	});
-}
+    /*
+     external references: view.tab.panel, view.tree.viewer ..
+    */
+    ConDecAPI.prototype.getTreeViewer = function getTreeViewer(rootElementType, callback) {
+        getJSON(AJS.contextPath() + "/rest/decisions/latest/view/getTreeViewer.json?projectKey=" + global.getProjectKey()
+                + "&rootElementType=" + rootElementType, function(error, core) {
+            if (error === null) {
+                callback(core);
+            } else {
+                showFlag("error", "Tree viewer data could not be received. Error-Code: " + error);
+            }
+        });
+    }
 
-function setIssueStrategy(isIssueStrategy, projectKey) {
-	postJSON(AJS.contextPath() + "/rest/decisions/latest/config/setIssueStrategy.json?projectKey=" + projectKey
-			+ "&isIssueStrategy=" + isIssueStrategy, null, function(error, response) {
-		if (error === null) {
-			showFlag("success", "Strategy has been selected.");
-		} else {
-			showFlag("error", "Strategy could not be selected.");
-		}
-	});
-}
+    /*
+     external references: view.treant ..
+    */
+    ConDecAPI.prototype.getTreant = function getTreant(elementKey, depthOfTree, searchTerm, callback) {
+        getJSON(AJS.contextPath() + "/rest/decisions/latest/view/getTreant.json?&elementKey=" + elementKey
+                + "&depthOfTree=" + depthOfTree + "&searchTerm=" + searchTerm, function(error, treant) {
+            if (error === null) {
+                callback(treant);
+            } else {
+                showFlag("error", "Filtered Treant data could not be received. Error-Code: " + error);
+            }
+        });
+    }
 
-function isIssueStrategy(projectKey, callback) {
-	getJSON(AJS.contextPath() + "/rest/decisions/latest/config/isIssueStrategy.json?projectKey=" + getProjectKey(),
-			function(error, isIssueStrategyBoolean) {
-				if (error === null) {
-					callback(isIssueStrategyBoolean);
-				} else {
-					showFlag("error", "Persistence strategy for the project could not be received. Error-Code: "
-							+ error);
-				}
-			});
-}
+    /*
+     external references: view.tab.panel ..
+    */
+    ConDecAPI.prototype.getTreeViewerWithoutRootElement = function getTreeViewerWithoutRootElement(showRelevant, callback) {
+        var issueId = AJS.$("meta[name='ajs-issue-key']").attr("content");
+        if (issueId === undefined) {
+            issueId = getIssueKey();
+        }
+        getJSON(AJS.contextPath() + "/rest/decisions/latest/view/getTreeViewer2.json?issueKey=" + issueId
+                + "&showRelevant=" + showRelevant, function(error, core) {
+            if (error === null) {
+                callback(core);
+            } else {
+                showFlag("error", "Tree viewer data could not be received. Error-Code: " + error);
+            }
+        });
+    }
 
-function setKnowledgeExtractedFromGit(isKnowledgeExtractedFromGit, projectKey) {
-	postJSON(AJS.contextPath() + "/rest/decisions/latest/config/setKnowledgeExtractedFromGit.json?projectKey="
-			+ projectKey + "&isKnowledgeExtractedFromGit=" + isKnowledgeExtractedFromGit, null,
-			function(error, response) {
-				if (error === null) {
-					showFlag("success", "Git connection for this project has been set to "
-							+ isKnowledgeExtractedFromGit + ".");
-				} else {
-					showFlag("error", "Git connection for this project could not be configured.");
-				}
-			});
-}
+    /*
+     external references: settingsForSingleProject.vm, settingsForAllProjects.vm ..
+    */
+    ConDecAPI.prototype.setActivated = function setActivated(isActivated, projectKey) {
+        postJSON(AJS.contextPath() + "/rest/decisions/latest/config/setActivated.json?projectKey=" + projectKey
+                + "&isActivated=" + isActivated, null, function(error, response) {
+            if (error === null) {
+                showFlag("success", "Plug-in activation for the project has been set to " + isActivated + ".");
+            } else {
+                showFlag("error", "Plug-in activation for the project has not been changed.");
+            }
+        });
+    }
 
-function isKnowledgeExtractedFromGit(projectKey, callback) {
-	getJSON(AJS.contextPath() + "/rest/decisions/latest/config/isKnowledgeExtractedFromGit.json?projectKey="
-			+ projectKey, function(error, isKnowledgeExtractedFromGit) {
-		if (error === null) {
-			callback(isKnowledgeExtractedFromGit);
-		} else {
-			showFlag("error", "It could not be received whether decision knowledge is extracted from git. Error-Code: "
-					+ error);
-		}
-	});
-}
+    /*
+     external references: settingsForSingleProject.vm, settingsForAllProjects.vm ..
+    */
+    ConDecAPI.prototype.setIssueStrategy = function setIssueStrategy(isIssueStrategy, projectKey) {
+        postJSON(AJS.contextPath() + "/rest/decisions/latest/config/setIssueStrategy.json?projectKey=" + projectKey
+                + "&isIssueStrategy=" + isIssueStrategy, null, function(error, response) {
+            if (error === null) {
+                showFlag("success", "Strategy has been selected.");
+            } else {
+                showFlag("error", "Strategy could not be selected.");
+            }
+        });
+    }
 
-function setKnowledgeExtractedFromIssues(isKnowledgeExtractedFromIssues, projectKey) {
-	postJSON(AJS.contextPath() + "/rest/decisions/latest/config/setKnowledgeExtractedFromIssues.json?projectKey="
-			+ projectKey + "&isKnowledgeExtractedFromIssues=" + isKnowledgeExtractedFromIssues, null, function(error,
-			response) {
-		if (error === null) {
-			showFlag("success", "Extraction from issue comments for this project has been set to "
-					+ isKnowledgeExtractedFromIssues + ".");
-		} else {
-			showFlag("error", "Extraction from issue comments for this project could not be configured.");
-		}
-	});
-}
 
-function setUseClassiferForIssueComments(isClassifierUsedForIssues, projectKey) {
-	postJSON(AJS.contextPath() + "/rest/decisions/latest/config/setUseClassiferForIssueComments.json?projectKey="
-			+ projectKey + "&isClassifierUsedForIssues=" + isClassifierUsedForIssues, null, function(error, response) {
-		if (error === null) {
-			showFlag("success", "Usage of classification for Decision Knowledge in Issue Comments has been set to "
-					+ isClassifierUsedForIssues + ".");
-		} else {
-			showFlag("error",
-					"Usage of classification for Decision Knowledge in Issue Comments could not be configured.");
-		}
-	});
-}
+    /*
+     external references: settingsForSingleProject.vm, settingsForAllProjects.vm, view.context.menu ..
+    */
+    ConDecAPI.prototype.isIssueStrategy = function isIssueStrategy(projectKey, callback) {
+        getJSON(AJS.contextPath() + "/rest/decisions/latest/config/isIssueStrategy.json?projectKey=" + global.getProjectKey(),
+                function(error, isIssueStrategyBoolean) {
+                    if (error === null) {
+                        callback(isIssueStrategyBoolean);
+                    } else {
+                        showFlag("error", "Persistence strategy for the project could not be received. Error-Code: "
+                                + error);
+                    }
+                });
+    }
 
-function isKnowledgeExtractedFromIssues(projectKey, callback) {
-	getJSON(AJS.contextPath() + "/rest/decisions/latest/config/isKnowledgeExtractedFromIssues.json?projectKey="
-			+ projectKey, function(error, isKnowledgeExtractedFromIssues) {
-		if (error === null) {
-			callback(isKnowledgeExtractedFromIssues);
-		} else {
-			showFlag("error",
-					"It could not be received whether decision knowledge is extracted from issue comments. Error-Code: "
-							+ error);
-		}
-	});
-}
+    /*
+     external references: settingsForSingleProject.vm, settingsForAllProjects.vm ..
+    */
+    ConDecAPI.prototype.setKnowledgeExtractedFromGit = function setKnowledgeExtractedFromGit(isKnowledgeExtractedFromGit, projectKey) {
+        postJSON(AJS.contextPath() + "/rest/decisions/latest/config/setKnowledgeExtractedFromGit.json?projectKey="
+                + projectKey + "&isKnowledgeExtractedFromGit=" + isKnowledgeExtractedFromGit, null,
+                function(error, response) {
+                    if (error === null) {
+                        showFlag("success", "Git connection for this project has been set to "
+                                + isKnowledgeExtractedFromGit + ".");
+                    } else {
+                        showFlag("error", "Git connection for this project could not be configured.");
+                    }
+                });
+    }
 
-function setKnowledgeTypeEnabled(isKnowledgeTypeEnabled, knowledgeType, projectKey) {
-	postJSON(AJS.contextPath() + "/rest/decisions/latest/config/setKnowledgeTypeEnabled.json?projectKey=" + projectKey
-			+ "&knowledgeType=" + knowledgeType + "&isKnowledgeTypeEnabled=" + isKnowledgeTypeEnabled, null, function(
-			error, response) {
-		if (error === null) {
-			showFlag("success", "The activation of the " + knowledgeType
-					+ " knowledge type for this project has been set to " + isKnowledgeTypeEnabled + ".");
-		} else {
-			showFlag("error", "The activation of the " + knowledgeType
-					+ " knowledge type for this project could not be changed.");
-		}
-	});
-}
+    /*
+     external references: view.treant ..
+    */
+    ConDecAPI.prototype.isKnowledgeExtractedFromGit = function isKnowledgeExtractedFromGit(projectKey, callback) {
+        getJSON(AJS.contextPath() + "/rest/decisions/latest/config/isKnowledgeExtractedFromGit.json?projectKey="
+                + projectKey, function(error, isKnowledgeExtractedFromGit) {
+            if (error === null) {
+                callback(isKnowledgeExtractedFromGit);
+            } else {
+                showFlag("error", "It could not be received whether decision knowledge is extracted from git. Error-Code: "
+                        + error);
+            }
+        });
+    }
 
-function isKnowledgeTypeEnabled(knowledgeType, projectKey, toggle, callback) {
-	getJSON(AJS.contextPath() + "/rest/decisions/latest/config/isKnowledgeTypeEnabled.json?knowledgeType="
-			+ knowledgeType + "&projectKey=" + projectKey, function(error, isKnowledgeTypeEnabled) {
-		if (error === null) {
-			callback(isKnowledgeTypeEnabled, toggle);
-		} else {
-			showFlag("error", "It could not be received whether the knowledge type is enabled. Error-Code: " + error);
-		}
-	});
-}
+    /*
+     external references: settingsForSingleProject.vm, settingsForAllProjects.vm ..
+    */
+    ConDecAPI.prototype.setKnowledgeExtractedFromIssues = function setKnowledgeExtractedFromIssues(isKnowledgeExtractedFromIssues, projectKey) {
+        postJSON(AJS.contextPath() + "/rest/decisions/latest/config/setKnowledgeExtractedFromIssues.json?projectKey="
+                + projectKey + "&isKnowledgeExtractedFromIssues=" + isKnowledgeExtractedFromIssues, null, function(error,
+                response) {
+            if (error === null) {
+                showFlag("success", "Extraction from issue comments for this project has been set to "
+                        + isKnowledgeExtractedFromIssues + ".");
+            } else {
+                showFlag("error", "Extraction from issue comments for this project could not be configured.");
+            }
+        });
+    }
 
-function getKnowledgeTypes(projectKey) {
-	var knowledgeTypes = getResponseAsReturnValue(AJS.contextPath()
-			+ "/rest/decisions/latest/config/getKnowledgeTypes.json?projectKey=" + projectKey);
-	if (knowledgeTypes !== null) {
-		return knowledgeTypes;
-	} else {
-		showFlag("error", "The knowledge types could not be received. Error-Code: " + error);
-	}
-}
+    /*
+     external references: settingsForSingleProject.vm ..
+    */
+    ConDecAPI.prototype.setUseClassiferForIssueComments = function setUseClassiferForIssueComments(isClassifierUsedForIssues, projectKey) {
+        postJSON(AJS.contextPath() + "/rest/decisions/latest/config/setUseClassiferForIssueComments.json?projectKey="
+                + projectKey + "&isClassifierUsedForIssues=" + isClassifierUsedForIssues, null, function(error, response) {
+            if (error === null) {
+                showFlag("success", "Usage of classification for Decision Knowledge in Issue Comments has been set to "
+                        + isClassifierUsedForIssues + ".");
+            } else {
+                showFlag("error",
+                        "Usage of classification for Decision Knowledge in Issue Comments could not be configured.");
+            }
+        });
+    }
 
-function getDefaultKnowledgeTypes(projectKey) {
-	var defaultKnowledgeTypes = getResponseAsReturnValue(AJS.contextPath()
-			+ "/rest/decisions/latest/config/getDefaultKnowledgeTypes.json?projectKey=" + projectKey);
-	if (defaultKnowledgeTypes !== null) {
-		return defaultKnowledgeTypes;
-	} else {
-		showFlag("error", "The default knowledge types could not be received. Error-Code: " + error);
-	}
-}
+    /*
+     external references: none, not even used locally, parameter naming ..
+    */
+    ConDecAPI.prototype.isKnowledgeExtractedFromIssues = function isKnowledgeExtractedFromIssues(projectKey, callback) {
+        getJSON(AJS.contextPath() + "/rest/decisions/latest/config/isKnowledgeExtractedFromIssues.json?projectKey="
+                + projectKey, function(error, isKnowledgeExtractedFromIssues) {
+            if (error === null) {
+                callback(isKnowledgeExtractedFromIssues);
+            } else {
+                showFlag("error",
+                        "It could not be received whether decision knowledge is extracted from issue comments. Error-Code: "
+                                + error);
+            }
+        });
+    }
 
-function setGitAddress(projectKey, gitAddress) {
-	postJSON(AJS.contextPath() + "/rest/decisions/latest/config/setGitAddress.json?projectKey=" + projectKey
-			+ "&gitAddress=" + gitAddress, null, function(error, response) {
-		if (error === null) {
-			showFlag("success", "The git address  " + gitAddress + " for this project has been set.");
-		} else {
-			showFlag("error", "The git address  " + gitAddress + " for this project could not be set.");
-		}
-	});
-}
+    /*
+     external references: settingsForSingleProject.vm ..
+    */
+    ConDecAPI.prototype.setKnowledgeTypeEnabled = function setKnowledgeTypeEnabled(isKnowledgeTypeEnabled, knowledgeType, projectKey) {
+        postJSON(AJS.contextPath() + "/rest/decisions/latest/config/setKnowledgeTypeEnabled.json?projectKey=" + projectKey
+                + "&knowledgeType=" + knowledgeType + "&isKnowledgeTypeEnabled=" + isKnowledgeTypeEnabled, null, function(
+                error, response) {
+            if (error === null) {
+                showFlag("success", "The activation of the " + knowledgeType
+                        + " knowledge type for this project has been set to " + isKnowledgeTypeEnabled + ".");
+            } else {
+                showFlag("error", "The activation of the " + knowledgeType
+                        + " knowledge type for this project could not be changed.");
+            }
+        });
+    }
 
-function getCommits(elementKey, callback) {
-	getJSON(AJS.contextPath() + "/rest/gitplugin/latest/issues/" + elementKey + "/commits",
-			function(error, commitData) {
-				if (error === null) {
-					callback(commitData.commits);
-				} else {
-					showFlag("error", "Commits for this element could not be received. Error-Code: " + error);
-					callback();
-				}
-			});
-}
+    /*
+     external references: settingsForSingleProject.vm
+    */
+    ConDecAPI.prototype.isKnowledgeTypeEnabled = function isKnowledgeTypeEnabled(knowledgeType, projectKey, toggle, callback) {
+        getJSON(AJS.contextPath() + "/rest/decisions/latest/config/isKnowledgeTypeEnabled.json?knowledgeType="
+                + knowledgeType + "&projectKey=" + projectKey, function(error, isKnowledgeTypeEnabled) {
+            if (error === null) {
+                callback(isKnowledgeTypeEnabled, toggle);
+            } else {
+                showFlag("error", "It could not be received whether the knowledge type is enabled. Error-Code: " + error);
+            }
+        });
+    }
 
-function setWebhookData(projectKey, webhookUrl, webhookSecret) {
-	postJSON(AJS.contextPath() + "/rest/decisions/latest/config/setWebhookData.json?projectKey=" + projectKey
-			+ "&webhookUrl=" + webhookUrl + "&webhookSecret=" + webhookSecret, null, function(error, response) {
-		if (error === null) {
-			showFlag("success", "The webhook for this project has been set.");
-		} else {
-			showFlag("error", "The webhook for this project has not been set.");
-		}
-	});
-}
+    /*
+     external references: management ..
+    */
+    ConDecAPI.prototype.getKnowledgeTypes = function getKnowledgeTypes(projectKey) {
+        var knowledgeTypes = getResponseAsReturnValue(AJS.contextPath()
+                + "/rest/decisions/latest/config/getKnowledgeTypes.json?projectKey=" + projectKey);
+        if (knowledgeTypes !== null) {
+            return knowledgeTypes;
+        } else {
+            showFlag("error", "The knowledge types could not be received. Error-Code: " + error);
+        }
+    }
 
-function setWebhookEnabled(isActivated, projectKey) {
-	postJSON(AJS.contextPath() + "/rest/decisions/latest/config/setWebhookEnabled.json?projectKey=" + projectKey
-			+ "&isActivated=" + isActivated, null, function(error, response) {
-		if (error === null) {
-			showFlag("success", "The webhook activation for this project has been changed.");
-		} else {
-			showFlag("error", "The webhook activation for this project could not be changed.");
-		}
-	});
-}
+    /*
+     external references: mangament ..
+    */
+    ConDecAPI.prototype.getDefaultKnowledgeTypes = function getDefaultKnowledgeTypes(projectKey) {
+        var defaultKnowledgeTypes = getResponseAsReturnValue(AJS.contextPath()
+                + "/rest/decisions/latest/config/getDefaultKnowledgeTypes.json?projectKey=" + projectKey);
+        if (defaultKnowledgeTypes !== null) {
+            return defaultKnowledgeTypes;
+        } else {
+            showFlag("error", "The default knowledge types could not be received. Error-Code: " + error);
+        }
+    }
 
-function getProjectIssueTypes(projectKey, callback) {
-	getJSON(AJS.contextPath() + "/rest/decisions/latest/config/getProjectIssueTypes.json?projectKey=" + projectKey,
-			function(error, issueTypes) {
-				if (error === null) {
-					callback(issueTypes);
-				} else {
-					showFlag("error", "Issue types of project could not be received. Error-Code: " + error);
-				}
-			});
-}
+    /*
+     external references: none, not even used locally! //TODO: delete function?
+    */
+    ConDecAPI.prototype.setGitAddress = function setGitAddress(projectKey, gitAddress) {
+        postJSON(AJS.contextPath() + "/rest/decisions/latest/config/setGitAddress.json?projectKey=" + projectKey
+                + "&gitAddress=" + gitAddress, null, function(error, response) {
+            if (error === null) {
+                showFlag("success", "The git address  " + gitAddress + " for this project has been set.");
+            } else {
+                showFlag("error", "The git address  " + gitAddress + " for this project could not be set.");
+            }
+        });
+    }
 
-function setWebhookType(webhookType, projectKey) {
-	postJSON(AJS.contextPath() + "/rest/decisions/latest/config/setWebhookType.json?projectKey=" + projectKey
-			+ "&webhookType=" + webhookType, null, function(error, response) {
-		if (error === null) {
-			showFlag("success", "The webhook root element type was changed for this project.");
-		} else {
-			showFlag("error", "The webhook root element type could not been changed for this project.");
-		}
-	});
-}
+    /*
+     external references: view.treant ..
+    */
+    ConDecAPI.prototype.getCommits = function getCommits(elementKey, callback) {
+        getJSON(AJS.contextPath() + "/rest/gitplugin/latest/issues/" + elementKey + "/commits",
+                function(error, commitData) {
+                    if (error === null) {
+                        callback(commitData.commits);
+                    } else {
+                        showFlag("error", "Commits for this element could not be received. Error-Code: " + error);
+                        callback();
+                    }
+                });
+    }
 
-function getCommitsAsReturnValue(elementKey) {
-	var commitData = getResponseAsReturnValue(AJS.contextPath() + "/rest/gitplugin/latest/issues/" + elementKey
-			+ "/commits");
-	return commitData.commits;
-}
+    /*
+     external references: settingsForSingleProject.vm ..
+    */
+    ConDecAPI.prototype.setWebhookData = function setWebhookData(projectKey, webhookUrl, webhookSecret) {
+        postJSON(AJS.contextPath() + "/rest/decisions/latest/config/setWebhookData.json?projectKey=" + projectKey
+                + "&webhookUrl=" + webhookUrl + "&webhookSecret=" + webhookSecret, null, function(error, response) {
+            if (error === null) {
+                showFlag("success", "The webhook for this project has been set.");
+            } else {
+                showFlag("error", "The webhook for this project has not been set.");
+            }
+        });
+    }
 
-function clearSentenceDatabase(projectKey) {
-	postJSON(AJS.contextPath() + "/rest/decisions/latest/config/clearSentenceDatabase.json?projectKey=" + projectKey,
-			null, function(error, response) {
-				if (error === null) {
-					showFlag("success", "The Sentence database has been cleared.");
-				} else {
-					showFlag("error", "The Sentence database has not been cleared.");
-				}
-			});
-}
+    /*
+     external references: settingsForSingleProject.vm
+    */
+    ConDecAPI.prototype.setWebhookEnabled = function setWebhookEnabled(isActivated, projectKey) {
+        postJSON(AJS.contextPath() + "/rest/decisions/latest/config/setWebhookEnabled.json?projectKey=" + projectKey
+                + "&isActivated=" + isActivated, null, function(error, response) {
+            if (error === null) {
+                showFlag("success", "The webhook activation for this project has been changed.");
+            } else {
+                showFlag("error", "The webhook activation for this project could not be changed.");
+            }
+        });
+    }
 
-function classifyWholeProject(projectKey) {
-	var isSucceeded = postWithResponseAsReturnValue(AJS.contextPath()
-			+ "/rest/decisions/latest/config/classifyWholeProject.json?projectKey=" + projectKey);
-	if (isSucceeded) {
-		showFlag("success", "The whole project has been classified.");
-		return 1.0;
-	}
-	showFlag("error", "The classification process failed.");
-	return 0.0;
-}
+    /*
+     external references: none, not even used locally! //TODO: delete function?
+    */
+    ConDecAPI.prototype.getProjectIssueTypes = function getProjectIssueTypes(projectKey, callback) {
+        getJSON(AJS.contextPath() + "/rest/decisions/latest/config/getProjectIssueTypes.json?projectKey=" + projectKey,
+                function(error, issueTypes) {
+                    if (error === null) {
+                        callback(issueTypes);
+                    } else {
+                        showFlag("error", "Issue types of project could not be received. Error-Code: " + error);
+                    }
+                });
+    }
 
-function setIconParsing(projectKey, isActivated) {
-	postJSON(AJS.contextPath() + "/rest/decisions/latest/config/setIconParsing.json?projectKey=" + projectKey
-			+ "&isActivatedString=" + isActivated, null, function(error, response) {
-		if (error === null) {
-			showFlag("success", "Using icons to tag issue comments has been set to " + isActivated + ".");
-		} else {
-			showFlag("error", "It could not be received wether icons can be used to tag issue comments.");
-		}
-	});
-}
+    /*
+     external references: settingsForSingleProject.vm ..
+    */
+    ConDecAPI.prototype.setWebhookType = function setWebhookType(webhookType, projectKey) {
+        postJSON(AJS.contextPath() + "/rest/decisions/latest/config/setWebhookType.json?projectKey=" + projectKey
+                + "&webhookType=" + webhookType, null, function(error, response) {
+            if (error === null) {
+                showFlag("success", "The webhook root element type was changed for this project.");
+            } else {
+                showFlag("error", "The webhook root element type could not been changed for this project.");
+            }
+        });
+    }
 
-function isIconParsing(projectKey, callback) {
-	getJSON(AJS.contextPath() + "/rest/decisions/latest/config/isIconParsing.json?projectKey=" + getProjectKey(),
-			function(error, isIconParsingBoolean) {
-				if (error === null) {
-					callback(isIconParsingBoolean);
-				} else {
-					showFlag("error",
-							"It could not be received wether icons can be used to tag issue comments. Error-Code: "
-									+ error);
-				}
-			});
-}
+    /*
+     external references: none, not even used locally! //TODO: delete function?
+    */
+    ConDecAPI.prototype.getCommitsAsReturnValue = function getCommitsAsReturnValue(elementKey) {
+        var commitData = getResponseAsReturnValue(AJS.contextPath() + "/rest/gitplugin/latest/issues/" + elementKey
+                + "/commits");
+        return commitData.commits;
+    }
 
-function getRequestToken(projectKey, baseURL, privateKey, consumerKey, callback) {
-	getJSON(AJS.contextPath() + "/rest/decisions/latest/config/getRequestToken.json?projectKey=" + projectKey
-			+ "&baseURL=" + baseURL + "&privateKey=" + privateKey + "&consumerKey=" + consumerKey, function(error,
-			result) {
-		if (error === null) {
-			callback(result);
-		} else {
-			showFlag("error", "Request token could not be received. Error-Code: " + error);
-		}
-	});
-}
+    /*
+     external references: settingsForSingleProject.vm ..
+    */
+    ConDecAPI.prototype.clearSentenceDatabase = function clearSentenceDatabase(projectKey) {
+        postJSON(AJS.contextPath() + "/rest/decisions/latest/config/clearSentenceDatabase.json?projectKey=" + projectKey,
+                null, function(error, response) {
+                    if (error === null) {
+                        showFlag("success", "The Sentence database has been cleared.");
+                    } else {
+                        showFlag("error", "The Sentence database has not been cleared.");
+                    }
+                });
+    }
 
-function getAccessToken(projectKey, baseURL, privateKey, consumerKey, requestToken, secret, callback) {
-	getJSON(AJS.contextPath() + "/rest/decisions/latest/config/getAccessToken.json?projectKey=" + projectKey
-			+ "&baseURL=" + baseURL + "&privateKey=" + privateKey + "&consumerKey=" + consumerKey + "&requestToken="
-			+ requestToken + "&secret=" + secret, function(error, result) {
-		if (error === null) {
-			callback(result);
-		} else {
-			showFlag("error", "Access token could not be received. Error-Code: " + error);
-		}
-	});
-}
+    /*
+     external references: settingsForSingleProject.vm ..
+    */
+    ConDecAPI.prototype.classifyWholeProject = function classifyWholeProject(projectKey) {
+        var isSucceeded = postWithResponseAsReturnValue(AJS.contextPath()
+                + "/rest/decisions/latest/config/classifyWholeProject.json?projectKey=" + projectKey);
+        if (isSucceeded) {
+            showFlag("success", "The whole project has been classified.");
+            return 1.0;
+        }
+        showFlag("error", "The classification process failed.");
+        return 0.0;
+    }
 
-function getElementsByQuery(query, callback) {
-	var projectKey = getProjectKey() || "";
-	postJSON(AJS.contextPath() + "/rest/decisions/latest/decisions/getAllElementsMatchingQuery.json?projectKey="
-			+ projectKey + "&query=" + query, null, function(error, result) {
-		if (error === null) {
-			callback(result);
-		} else {
-			showFlag("error", "Elements for given query could not be received." + error);
-		}
-	});
-}
+    /*
+     external references: settingsForSingleProject.vm ..
+    */
+    ConDecAPI.prototype.setIconParsing = function setIconParsing(projectKey, isActivated) {
+        postJSON(AJS.contextPath() + "/rest/decisions/latest/config/setIconParsing.json?projectKey=" + projectKey
+                + "&isActivatedString=" + isActivated, null, function(error, response) {
+            if (error === null) {
+                showFlag("success", "Using icons to tag issue comments has been set to " + isActivated + ".");
+            } else {
+                showFlag("error", "It could not be received wether icons can be used to tag issue comments.");
+            }
+        });
+    }
 
-function getLinkedElementsByQuery(query, elementKey, callback) {
-	getJSON(AJS.contextPath() + "/rest/decisions/latest/decisions/getAllElementsLinkedToElement.json?elementKey="
-			+ elementKey + "&URISearch=" + query, function(error, result) {
-		if (error === null) {
-			callback(result);
-		} else {
-			showFlag("error", "Linked elements for given query could not be received." + error);
-		}
-	});
-}
+    /*
+     external references: none, not even used locally! //TODO: delete function?
+    */
+    ConDecAPI.prototype.isIconParsing = function isIconParsing(projectKey, callback) {
+        getJSON(AJS.contextPath() + "/rest/decisions/latest/config/isIconParsing.json?projectKey=" + global.getProjectKey(),
+                function(error, isIconParsingBoolean) {
+                    if (error === null) {
+                        callback(isIconParsingBoolean);
+                    } else {
+                        showFlag("error",
+                                "It could not be received wether icons can be used to tag issue comments. Error-Code: "
+                                        + error);
+                    }
+                });
+    }
+
+    /*
+     external references: settingsForAllProjects.vm ..
+    */
+    ConDecAPI.prototype.getRequestToken = function getRequestToken(projectKey, baseURL, privateKey, consumerKey, callback) {
+        getJSON(AJS.contextPath() + "/rest/decisions/latest/config/getRequestToken.json?projectKey=" + projectKey
+                + "&baseURL=" + baseURL + "&privateKey=" + privateKey + "&consumerKey=" + consumerKey, function(error,
+                result) {
+            if (error === null) {
+                callback(result);
+            } else {
+                showFlag("error", "Request token could not be received. Error-Code: " + error);
+            }
+        });
+    }
+
+    /*
+     external references: settingsForAllProjects.vm ..
+    */
+    ConDecAPI.prototype.getAccessToken = function getAccessToken(projectKey, baseURL, privateKey, consumerKey, requestToken, secret, callback) {
+        getJSON(AJS.contextPath() + "/rest/decisions/latest/config/getAccessToken.json?projectKey=" + projectKey
+                + "&baseURL=" + baseURL + "&privateKey=" + privateKey + "&consumerKey=" + consumerKey + "&requestToken="
+                + requestToken + "&secret=" + secret, function(error, result) {
+            if (error === null) {
+                callback(result);
+            } else {
+                showFlag("error", "Access token could not be received. Error-Code: " + error);
+            }
+        });
+    }
+
+    /*
+     external references: view.issue.module ..
+    */
+    ConDecAPI.prototype.getElementsByQuery = function getElementsByQuery(query, callback) {
+        var projectKey = global.getProjectKey() || "";
+        postJSON(AJS.contextPath() + "/rest/decisions/latest/decisions/getAllElementsMatchingQuery.json?projectKey="
+                + projectKey + "&query=" + query, null, function(error, result) {
+            if (error === null) {
+                callback(result);
+            } else {
+                showFlag("error", "Elements for given query could not be received." + error);
+            }
+        });
+    }
+
+    /*
+     external references: view.issue.module ..
+    */
+    ConDecAPI.prototype.getLinkedElementsByQuery = function getLinkedElementsByQuery(query, elementKey, callback) {
+        getJSON(AJS.contextPath() + "/rest/decisions/latest/decisions/getAllElementsLinkedToElement.json?elementKey="
+                + elementKey + "&URISearch=" + query, function(error, result) {
+            if (error === null) {
+                callback(result);
+            } else {
+                showFlag("error", "Linked elements for given query could not be received." + error);
+            }
+        });
+    }
+    
+    // export ConDecAPI
+    global.conDecAPI = new ConDecAPI();
+})(window);

--- a/src/main/resources/js/view.context.menu.js
+++ b/src/main/resources/js/view.context.menu.js
@@ -76,7 +76,7 @@ function setUpDialogForCreateAction(id) {
 		closeDialog();
 	};
 
-	isIssueStrategy(id, function(isIssueStrategy) {
+	conDecAPI.isIssueStrategy(id, function(isIssueStrategy) { //TODO: rename param name, confusing.
 		if (isIssueStrategy === true) {
 			var extensionButton = document.getElementById("dialog-extension-button");
 			extensionButton.style.visibility = "visible";
@@ -169,7 +169,7 @@ function setUpDialogForLinkAction(id) {
 	setUpDialog();
 	setHeaderText(linkKnowledgeElementText);
 
-	getUnlinkedElements(id, function(unlinkedElements) {
+	conDecAPI.getUnlinkedElements(id, function(unlinkedElements) {
 		var insertString = "<form class='aui'><div class='field-group' id='select-field-group'></div>"
 				+ "<div class='field-group' id='argument-field-group'></div></form>";
 		var content = document.getElementById("dialog-content");
@@ -203,7 +203,7 @@ function addFormForArguments() {
 	var childId = $("select[name='form-select-component']").val();
 	var argumentFieldGroup = document.getElementById("argument-field-group");
 	argumentFieldGroup.innerHTML = "";
-	getDecisionKnowledgeElement(
+	conDecAPI.getDecisionKnowledgeElement(
 			childId,
 			function(decisionKnowledgeElement) {
 				if (decisionKnowledgeElement && decisionKnowledgeElement.type === "Argument") {
@@ -235,7 +235,7 @@ function setUpDialogForEditAction(id, type) {
 	console.log("view.context.menu.js setUpDialogForEditAction");
 	setUpDialog();
 	setHeaderText(editKnowledgeElementText);
-	getDecisionKnowledgeElement(id, function(decisionKnowledgeElement) {
+	conDecAPI.getDecisionKnowledgeElement(id, function(decisionKnowledgeElement) {
 		var summary = decisionKnowledgeElement.summary;
 		var description = decisionKnowledgeElement.description;
 		var type = decisionKnowledgeElement.type;
@@ -251,7 +251,7 @@ function setUpDialogForEditAction(id, type) {
 			closeDialog();
 		};
 
-		isIssueStrategy(id, function(isIssueStrategy) {
+		conDecAPI.isIssueStrategy(id, function(isIssueStrategy) { // TODO: refactor param name, confusing!
 			if (isIssueStrategy === true) {
 				var extensionButton = document.getElementById("dialog-extension-button");
 				extensionButton.style.visibility = "visible";
@@ -294,7 +294,7 @@ function setUpDialogForDeleteAction(id) {
 	var submitButton = document.getElementById("dialog-submit-button");
 	submitButton.textContent = deleteKnowledgeElementText;
 	submitButton.onclick = function() {
-		deleteDecisionKnowledgeElement(id, function() {
+		conDecAPI.deleteDecisionKnowledgeElement(id, function() {
 			updateView();
 		});
 		closeDialog();
@@ -329,7 +329,7 @@ function setUpDialogForDeleteLinkAction(id, parentId) {
 	var submitButton = document.getElementById("dialog-submit-button");
 	submitButton.textContent = deleteLinkToParentText;
 	submitButton.onclick = function() {
-		deleteLink(parentId, id, function() {
+		conDecAPI.deleteLink(parentId, id, function() {
 			updateView();
 		});
 		closeDialog();
@@ -422,7 +422,7 @@ var changeKnowledgeTypeAction = {
 
 /* TODO: refactor name. "changeKnowledgeTypetTo" ? */ 
 function changeKtTo(id, position, type) {
-	changeKnowledgeTypeOfSentence(id, type, function() {
+	conDecAPI.changeKnowledgeTypeOfSentence(id, type, function() {
 		if (document.getElementById("Relevant") !== null) {
 			resetTreeViewer();
 			conDecIssueTab.buildTreeViewer(document.getElementById("Relevant").checked);
@@ -480,13 +480,13 @@ var contextMenuDeleteSentenceLinkAction = {
 
 		var nodeType = (node.li_attr['class'] === "sentence") ? "s" : "i";
 
-		deleteGenericLink(parentId, node.id, "i", nodeType, refreshTreeViewer, false);
-		deleteGenericLink(parentId, node.id, "s", nodeType, refreshTreeViewer, false);
+		conDecAPI.deleteGenericLink(parentId, node.id, "i", nodeType, refreshTreeViewer, false);
+		conDecAPI.deleteGenericLink(parentId, node.id, "s", nodeType, refreshTreeViewer, false);
 	},
 	"callback" : function(key, options) {
 		var id = getSelectedTreantNodeId(options);
 		var parentId = findParentId(id);
-		deleteGenericLink(parentId, id, function(core) {
+		conDecAPI.deleteGenericLink(parentId, id, function(core) {
 			updateView();
 		});
 
@@ -501,7 +501,7 @@ var contextMenuDeleteSentenceAction = {
 	"action" : function(position) {
 		var node = getSelectedTreeViewerNode(position);
 		var id = node.id;
-		setSentenceIrrelevant(id, function(core, node) {
+		conDecAPI.setSentenceIrrelevant(id, function(core, node) {
 			jQueryConDec("#jstree").jstree(true).set_icon(jQueryConDec("#jstree").jstree(true).get_node(id),
 					"https://player.fm/static/images/128pixel.png");
 			if (!(document.getElementById("Relevant") == null)) {
@@ -515,7 +515,7 @@ var contextMenuDeleteSentenceAction = {
 	},
 	"callback" : function(key, options) {
 		var id = getSelectedTreantNodeId(options);
-		setSentenceIrrelevant(id, function(core, options, id) {
+		conDecAPI.setSentenceIrrelevant(id, function(core, options, id) {
 			refreshTreeViewer();
 		});
 	}
@@ -613,7 +613,7 @@ function setUpEditSentenceDialogContext(id, description, type) {
 	submitButton.onclick = function() {
 		var description = document.getElementById("form-input-description").value;
 		var type = $("select[name='form-select-type']").val().split("-")[0];
-		editSentenceBody(
+		conDecAPI.editSentenceBody(
 				id,
 				description,
 				type,

--- a/src/main/resources/js/view.context.menu.js
+++ b/src/main/resources/js/view.context.menu.js
@@ -632,7 +632,7 @@ function setUpEditSentenceDialogContext(id, description, type) {
 						updateView();
 					}
 
-					 callDialog();
+					 conDecIssueTab.callDialog();
 				});
 	};
 	AJS.$("#form-select-type").auiSelect2();

--- a/src/main/resources/js/view.decision.knowledge.page.js
+++ b/src/main/resources/js/view.decision.knowledge.page.js
@@ -1,75 +1,204 @@
-function initializeDecisionKnowledgePage() {
-    console.log("view.decision.knowledge.page initializeDecisionKnowledgePage");
-	for (var index = 0; index < knowledgeTypes.length; index++) {
-		var isSelected = "";
-		if (knowledgeTypes[index] === "Decision") {
-			isSelected = "selected ";
-		}
-		jQueryConDec("select[name='select-root-element-type']")[0].insertAdjacentHTML("beforeend", "<option " + isSelected + " value='"
-				+ knowledgeTypes[index] + "'>" + knowledgeTypes[index] + "</option>");
-	}
+/*
+ This decision knowledge view controller does:
+ * render decision tree
+ * provide a list of action items for the context menu
 
-	var createElementButton = document.getElementById("create-element-button");
-	var elementInputField = document.getElementById("element-input-field");
-	createElementButton.addEventListener("click", function() {
-		var summary = elementInputField.value;
-		var type = jQueryConDec("select[name='select-root-element-type']").val();
-		elementInputField.value = "";
-		createDecisionKnowledgeElement(summary, "", type, function(id) {
-			updateView(id);
-		});
-	});
+ Requires
+ * rest.client.js
+ * management.js
+ * view.treant.js
+ * view.tree.viewer.js
+ * view.context.menu.js
 
-	var depthOfTreeInput = document.getElementById("depth-of-tree-input");
-	depthOfTreeInput.addEventListener("input", function() {
-		var depthOfTreeWarningLabel = document.getElementById("depth-of-tree-warning");
-		if (this.value > 0) {
-			depthOfTreeWarningLabel.style.visibility = "hidden";
-			updateView();
-		} else {
-			depthOfTreeWarningLabel.style.visibility = "visible";
-		}
-	});
+ Required by
+ * view.context.menu.js
+ * decisionKnowledgePage.vm
 
-	updateView();
-}
+ Referenced in HTML by
+ * decisionKnowledgePage.vm
+*/
+(function (global) {
+    /* private vars */
+    var contextMenu = null;
+    var i18n = null;
+    var management = null;
+    var restClient = null;
+    var treant = null;
+    var treeViewer = null;
 
-function updateView(nodeId) {
-    console.log("view.decision.knowledge.page updateView");
-	buildTreeViewer();
-	if (nodeId === undefined) {
-		var rootElement = getCurrentRootElement();
-		if (rootElement) {
-			selectNodeInTreeViewer(rootElement.id);
-		}
-	} else {
-		selectNodeInTreeViewer(nodeId);
-	}
-	jQueryConDec("#jstree").on("select_node.jstree", function(error, tree) {
-		var node = tree.node.data;
-		buildTreant(node.key, true,"");
-	});
-}
+    var ConDecKnowledgePage = function ConDecKnowledgePage() {
+    };
 
-function setAsRootElement(nodeId) {
-	selectNodeInTreeViewer(nodeId);
-}
+    ConDecKnowledgePage.prototype.init = function(_restClient, _management, _treant, _treeViewer, _contextMenu, _i18n) {
+        console.log("view.decision.knowledge.page init");
 
-function openIssue(nodeId) {
-	// only allow this in case the selected node is a JIRA issue, for sentences map to JIRA issue
-	getDecisionKnowledgeElement(nodeId, function(decisionKnowledgeElement) {
-		var baseUrl = AJS.params.baseURL;
-		var key = decisionKnowledgeElement.key;
-		window.open(baseUrl + "/browse/" + key, '_blank');
-	});	
-}
+        if ( isConDecRestClientType(_restClient) &&
+             isConDecManagementType(_management) &&
+             isConDecTreantType(_treant) &&
+             isConDecTreeViewerType(_treeViewer) &&
+             isConDecContextType(_contextMenu) // not using and thus not checking i18n yet.
+            ) {
+            restClient = _restClient;
+            management = _management;
+            treant = _treant;
+            treeViewer = _treeViewer;
+            contextMenu = _contextMenu;
+            i18n = _i18n;
 
-var contextMenuActionsTreant = {
-		"asRoot" : contextMenuSetAsRootAction,
-		"create" : contextMenuCreateAction,
-		"edit" : contextMenuEditAction,
-		"link" : contextMenuLinkAction,
-		"deleteLink" : contextMenuDeleteLinkAction,
-		"delete" : contextMenuDeleteAction,
-		"openIssue" : contextMenuOpenJiraIssueAction
+            return true;
+            }
+        return false;
+    }
+
+    ConDecKnowledgePage.prototype.fetchAndRender = function () {
+        initializeDecisionKnowledgePage(restClient, management, treant, treeViewer);
+    }
+
+    ConDecKnowledgePage.prototype.setAsRootElement = function setAsRootElement(id) {
+        console.log("view.decision.knowledge.page setAsRootElement");
+        treeViewer.selectNodeInTreeViewer(nodeId);
+    }
+
+    ConDecKnowledgePage.prototype.openIssue = function openIssue(nodeId) {
+        console.log("view.decision.knowledge.page openIssue");
+
+        // only allow this in case the selected node is a JIRA issue, for sentences map to JIRA issue
+        restClient.getDecisionKnowledgeElement(nodeId, function(decisionKnowledgeElement) {
+            var baseUrl = AJS.params.baseURL;
+            var key = decisionKnowledgeElement.key;
+            window.open(baseUrl + "/browse/" + key, '_blank');
+        });
+    }
+
+    function initializeDecisionKnowledgePage(restClient, management, treant, treeViewer) {
+        console.log("view.decision.knowledge.page initializeDecisionKnowledgePage");
+
+        var knowledgeTypes = management.knowledgeTypes;
+        for (var index = 0; index < knowledgeTypes.length; index++) {
+            var isSelected = "";
+            if (knowledgeTypes[index] === "Decision") {
+                isSelected = "selected ";
+            }
+            jQueryConDec("select[name='select-root-element-type']")[0].insertAdjacentHTML("beforeend", "<option " + isSelected + " value='"
+                    + knowledgeTypes[index] + "'>" + knowledgeTypes[index] + "</option>");
+        }
+
+        var createElementButton = document.getElementById("create-element-button");
+        var elementInputField = document.getElementById("element-input-field");
+        createElementButton.addEventListener("click", function() {
+            var summary = elementInputField.value;
+            var type = jQueryConDec("select[name='select-root-element-type']").val();
+            elementInputField.value = "";
+            restClient.createDecisionKnowledgeElement(summary, "", type, function(id) {
+                updateView(id,treant,treeViewer);
+            });
+        });
+
+        var depthOfTreeInput = document.getElementById("depth-of-tree-input");
+        depthOfTreeInput.addEventListener("input", function() {
+            var depthOfTreeWarningLabel = document.getElementById("depth-of-tree-warning");
+            if (this.value > 0) {
+                depthOfTreeWarningLabel.style.visibility = "hidden";
+                updateView(null,treant,treeViewer);
+            } else {
+                depthOfTreeWarningLabel.style.visibility = "visible";
+            }
+        });
+
+        updateView(null,treant,treeViewer);
+    }
+
+    function updateView(nodeId, treant, treeViewer) {
+        console.log("view.decision.knowledge.page updateView");
+        treeViewer.buildTreeViewer();
+        if (nodeId === undefined) {
+            var rootElement = treant.getCurrentRootElement();
+            if (rootElement) {
+                treeViewer.selectNodeInTreeViewer(rootElement.id);
+            }
+        } else {
+            treeViewer.selectNodeInTreeViewer(nodeId);
+        }
+        jQueryConDec("#jstree").on("select_node.jstree", function(error, tree) {
+            var node = tree.node.data;
+            treant.buildTreant(node.key, true,"",getContextMenuActionsForTreant(contextMenu));
+        });
+    }
+
+
+    // for view.context.menu
+    function getContextMenuActionsForTreant(contextMenu) {
+        console.log("view.decision.knowledge.page getContextMenuActionsForTreant");
+        var menu =
+		{ "asRoot" : contextMenu.contextMenuSetAsRootAction
+		, "create" : contextMenu.contextMenuCreateAction
+		, "edit" : contextMenu.contextMenuEditAction
+		, "link" : contextMenu.contextMenuLinkAction
+		, "deleteLink" : contextMenu.contextMenuDeleteLinkAction
+		, "delete" : contextMenu.contextMenuDeleteAction
+		, "openIssue" : contextMenu.contextMenuOpenJiraIssueAction
+        };
+        return menu;
 	};
+
+
+    /*
+     Init Helpers
+    */
+    function isConDecRestClientType(restClient) {
+        if (!( restClient!=undefined
+                && restClient.getDecisionKnowledgeElement!=undefined
+                && typeof restClient.getDecisionKnowledgeElement === 'function' ))
+            {
+                console.warn("ConDecKnowledgePage: invalid restClient object received.")
+                return false;
+            }
+        return true;
+    }
+
+    function isConDecManagementType(management) {
+        if (!( management!=undefined
+            && management.getIssueKey!=undefined
+            && typeof management.getIssueKey === 'function' ))
+        {
+            console.warn("ConDecKnowledgePage: invalid management object received.")
+            return false;
+        }
+        return true;
+    }
+
+    function isConDecTreantType(treant) {
+        if (!( treant!=undefined
+            && treant.buildTreant!=undefined
+            && typeof treant.buildTreant === 'function' ))
+        {
+            console.warn("ConDecKnowledgePage: invalid treant object received.")
+            return false;
+        }
+        return true;
+    }
+
+    function isConDecContextType(contextMenu) {
+        if (!( contextMenu!=undefined
+            && contextMenu.setUpDialog!=undefined
+            && typeof contextMenu.setUpDialog === 'function' ))
+        {
+            console.warn("ConDecKnowledgePage: invalid contextMenu object received.")
+            return false;
+        }
+        return true;
+    }
+
+    function isConDecTreeViewerType(treeViewer) {
+        if (!( treeViewer!=undefined
+            && treeViewer.selectNodeInTreeViewer!=undefined
+            && typeof treeViewer.selectNodeInTreeViewer === 'function' ))
+        {
+            console.warn("ConDecKnowledgePage: invalid treeViewer object received.")
+            return false;
+        }
+        return true;
+    }
+    // export ConDecKnowledgePage
+    global.conDecKnowledgePage = new ConDecKnowledgePage();
+})(window);

--- a/src/main/resources/js/view.issue.module.js
+++ b/src/main/resources/js/view.issue.module.js
@@ -1,41 +1,158 @@
-function fillIssueModule() {
-	console.log("view.issue.module fillIssueModule");
-	
-	var exportMenuItem = document.getElementById("export-as-table-link");
-	exportMenuItem.addEventListener("click", function(e) {
-	    e.preventDefault();
-	    e.stopPropagation();
-		console.log("view.issue.module exportDecisionKnowledge");
-		AJS.dialog2("#export-dialog").show();
-	});
+/*
+ This issue module view controller does:
+ * render decision tree
+ * provide a list of action items for the context menu
+ * OUT OF SCOPE for now set onclick events to button for exporting as table
 
-	updateView();
-}
+ Requires
+ * rest.client.js
+ * management.js
+ * view.treant.js
+ * view.context.menu.js
 
-function updateView() {
-	console.log("view.issue.module updateView");
-	var issueKey = getIssueKey();
-	var search = getURLsSearch();
-	buildTreant(issueKey, true, search);
-}
+ Required by
+ * view.context.menu.js
+ * tabPanel.vm
 
-function setAsRootElement(id) {
-	getDecisionKnowledgeElement(id, function(decisionKnowledgeElement) {
-		var baseUrl = AJS.params.baseURL;
-		var key = decisionKnowledgeElement.key;
-		window.open(baseUrl + "/browse/" + key, '_self');
-	});
-}
+ Referenced in HTML by
+ * tabPanel.vm
+*/
+(function (global) {
+    /* private vars */
+    var contextMenu = null;
+    var i18n = null;
+    var management = null;
+    var restClient = null;
+    var treant = null;
 
-var contextMenuActionsTreant = {
-	"asRoot" : contextMenuSetAsRootAction,
-	"create" : contextMenuCreateAction,
-	"edit" : contextMenuEditAction,
-	"link" : contextMenuLinkAction,
-	"deleteLink" : contextMenuDeleteLinkAction,
-	"delete" : contextMenuDeleteAction
-};
+    var ConDecIssueModule = function ConDecIssueModule() {
+    };
 
+    ConDecIssueModule.prototype.init = function init(_restClient, _management, _treant, _contextMenu, _i18n) {
+        console.log("view.issue.module init");
+
+        if ( isConDecRestClientType(_restClient) &&
+             isConDecManagementType(_management) &&
+             isConDecTreantType(_treant) &&
+             isConDecContextType(_contextMenu) // not using and thus not checking i18n yet.
+            ) {
+            restClient = _restClient;
+            management = _management;
+            treant = _treant;
+            contextMenu = _contextMenu;
+            i18n = _i18n;
+
+            addOnClickEventToExportAsTable();
+
+            return true;
+        }
+        return false;
+    };
+
+    ConDecIssueModule.prototype.initView = function initView() {
+        console.log("view.issue.module initView");
+
+        updateView(management, treant, contextMenu);
+    }
+
+    // for view.context.menu
+    ConDecIssueModule.prototype.setAsRootElement = function setAsRootElement(id) {
+        console.log("view.issue.module setAsRootElement",id);
+        restClient.getDecisionKnowledgeElement(id, function(decisionKnowledgeElement) {
+            var baseUrl = AJS.params.baseURL;
+            var key = decisionKnowledgeElement.key;
+            window.open(baseUrl + "/browse/" + key, '_self'); // TODO: why window open ?
+        });
+    }
+
+    function addOnClickEventToExportAsTable() {
+	    console.log("view.issue.module addOnClickEventToExportAsTable");
+
+        var exportMenuItem = document.getElementById("export-as-table-link");
+        if (!exportMenuItem) return;
+        exportMenuItem.addEventListener("click", function(e) {
+            e.preventDefault();
+            e.stopPropagation();
+            console.log("view.issue.module exportDecisionKnowledge");
+            AJS.dialog2("#export-dialog").show();
+        });
+    }
+
+    // for view.context.menu
+    function getContextMenuActionsForTreant(contextMenu) {
+        console.log("view.issue.module getContextMenuActionsForTreant");
+        var menu =
+        { "asRoot" : contextMenu.contextMenuSetAsRootAction
+        , "create" : contextMenu.contextMenuCreateAction
+        , "edit" : contextMenu.contextMenuEditAction
+        , "link" : contextMenu.contextMenuLinkAction
+        , "deleteLink" : contextMenu.contextMenuDeleteLinkAction
+        , "delete" : contextMenu.contextMenuDeleteAction
+        };
+        return menu;
+    }
+
+    function updateView(management,treant,contextMenu) {
+	    console.log("view.issue.module updateView");
+        var issueKey = management.getIssueKey();
+        var search = management.getURLsSearch();
+        treant.buildTreant(issueKey, true, search, getContextMenuActionsForTreant(contextMenu) );
+    }
+
+    /*
+     Init Helpers
+    */
+    function isConDecRestClientType(restClient) {
+        if (!( restClient!=undefined
+                && restClient.getDecisionKnowledgeElement!=undefined
+                && typeof restClient.getDecisionKnowledgeElement === 'function' ))
+            {
+                console.warn("ConDecIssueModule: invalid restClient object received.")
+                return false;
+            }
+        return true;
+    }
+
+    function isConDecManagementType(management) {
+        if (!( management!=undefined
+            && management.getIssueKey!=undefined
+            && typeof management.getIssueKey === 'function' ))
+        {
+            console.warn("ConDecIssueModule: invalid management object received.")
+            return false;
+        }
+        return true;
+    }
+
+    function isConDecTreantType(buildTreant) {
+        if (!( buildTreant!=undefined
+            && buildTreant.buildTreant!=undefined
+            && typeof buildTreant.buildTreant === 'function' ))
+        {
+            console.warn("ConDecIssueModule: invalid buildTreant object received.")
+            return false;
+        }
+        return true;
+    }
+
+    function isConDecContextType(contextMenu) {
+        if (!( contextMenu!=undefined
+            && contextMenu.setUpDialog!=undefined
+            && typeof contextMenu.setUpDialog === 'function' ))
+        {
+            console.warn("ConDecIssueModule: invalid contextMenu object received.")
+            return false;
+        }
+        return true;
+    }
+
+    // export ConDecIssueModule
+    global.conDecIssueModule = new ConDecIssueModule();
+})(window);
+
+/* OUT of scope for Restructing:
+ ExportAsTable functions
+*/
 function closeExportDialog() {
 	AJS.dialog2("#export-dialog").hide();
 }
@@ -62,6 +179,7 @@ function exportLinkedElements() {
 			}
 		}
 	});
+
 }
 
 /**
@@ -121,3 +239,5 @@ function download(filename, text) {
 	element.click();
 	document.body.removeChild(element);
 }
+
+

--- a/src/main/resources/js/view.tab.panel.js
+++ b/src/main/resources/js/view.tab.panel.js
@@ -13,13 +13,28 @@
  Referenced in HTML by
  * tabPanel.vm 
 */
-(function (global, _restClient, _i18n) {
-    var restClient = _restClient;
-    var i18n = _i18n;
+(function (global) {
+    /* private vars */
+    var contextMenu = null;
+    var restClient = null;
+    var treeViewer = null;
+    var i18n = null;
     
     var ConDecIssueTab = function ConDecIssueTab() {
     };
-    
+
+    ConDecIssueTab.prototype.init = function init(_restClient, _treeViewer, _contextMenu, _i18n) {
+        console.log("view.tab.panel.js init");
+
+        // TODO add simple type checks
+        restClient = _restClient;
+        treeViewer = _treeViewer;
+        contextMenu = _contextMenu;
+        i18n = _i18n;
+
+        return true;
+    }
+
     /* triggered by onchange event in tabPanel.vm */
     function toggleSelectedDecisionElements(element) {
         console.log("view.tab.panel.js toggleSelectedDecisionElements");
@@ -63,7 +78,7 @@
             console.log("view.tab.panel.js close.onclick");
             AJS.dialog2("#dialog").hide();
         };
-        setUpDialog();
+        contextMenu.setUpDialog();
         var header = document.getElementById("dialog-header");
         header.textContent = textheader;
     }
@@ -78,7 +93,7 @@
         document.getElementById("dialog").classList.remove("aui-dialog2-medium");
         document.getElementById("dialog").classList.add("aui-dialog2-large");
         $("#dialog-extension-button").remove();
-        $("#dialog-cancel-button").remove();
+        $("#dialog #dialog-cancel-button").remove();
 
         buildTreeViewer(document.getElementById("Relevant").checked);
     }
@@ -86,8 +101,7 @@
     /*
 
      called by
-     * view.tab.panel.js
-        lines: 43
+     * view.tab.panel.js:callDialog
      * view.context.menu.js
         lines: 414,617
     */
@@ -112,7 +126,7 @@
                 var searchString = $(this).val();
                 jQueryConDec("#jstree").jstree(true).search(searchString);
             });
-            addDragAndDropSupportForTreeViewer();
+            treeViewer.addDragAndDropSupportForTreeViewer();
             document.getElementById("jstree").addEventListener("mousemove", bringContextMenuToFront);
         });
     }
@@ -166,6 +180,6 @@
     // for view.context.menu.js
     ConDecIssueTab.prototype.buildTreeViewer = buildTreeViewer;
         
-    // initialize ConDecIssueTab
+    // export ConDecIssueTab
     global.conDecIssueTab= new ConDecIssueTab();
-})(window,window,null); //TODO: replace 2nd param with rest client object 
+})(window);

--- a/src/main/resources/js/view.treant.js
+++ b/src/main/resources/js/view.treant.js
@@ -5,7 +5,8 @@ var treantTree;
 
 var draggedElement;
 
-function buildTreant(elementKey, isInteractive, searchTerm) {
+function buildTreant(elementKey, isInteractive, searchTerm, contextMenuActions) {
+    console.log("view.treant.js buildTreant");
     var depthOfTree = getDepthOfTree();
     getTreant(elementKey, depthOfTree, searchTerm, function(treeStructure) {
         document.getElementById("treant-container").innerHTML = "";
@@ -19,10 +20,10 @@ function buildTreant(elementKey, isInteractive, searchTerm) {
                                 treeStructure.nodeStructure.children);
                         }
                         // console.log(treeStructure);
-                        createTreant(treeStructure, isInteractive);
+                        createTreant(treeStructure, isInteractive, contextMenuActions);
                     });
             } else {
-                createTreant(treeStructure, isInteractive);
+                createTreant(treeStructure, isInteractive, contextMenuActions);
             }
         });
     });
@@ -39,22 +40,24 @@ function getDepthOfTree() {
 	return depthOfTree;
 }
 
-function createTreant(treeStructure, isInteractive) {
+function createTreant(treeStructure, isInteractive, contextMenuActions) {
 	console.log("view.treant.js createTreant");
+    if (contextMenuActions == undefined)
+        contextMenuActions = contextMenuActionsTreant;
 	treantTree = new Treant(treeStructure);
 	if (isInteractive !== undefined && isInteractive) {
 		createContextMenuForTreantNodesThatAreSentence();
-		createContextMenuForTreantNodes();
+		createContextMenuForTreantNodes(contextMenuActions);
 		addDragAndDropSupportForTreant();
 		addTooltip();
 	}
 }
 
-function createContextMenuForTreantNodes() {
+function createContextMenuForTreantNodes(contextMenuActions) {
 	jQueryConDec(function() {
 		jQueryConDec.contextMenu({
 			selector : ".decision, .rationale, .context, .problem, .solution, .pro, .contra, .other",
-			items : contextMenuActionsTreant
+			items : contextMenuActions
 		});
 	});
 }

--- a/src/main/resources/js/view.treant.js
+++ b/src/main/resources/js/view.treant.js
@@ -8,12 +8,12 @@ var draggedElement;
 function buildTreant(elementKey, isInteractive, searchTerm, contextMenuActions) {
     console.log("view.treant.js buildTreant");
     var depthOfTree = getDepthOfTree();
-    getTreant(elementKey, depthOfTree, searchTerm, function(treeStructure) {
+    conDecAPI.getTreant(elementKey, depthOfTree, searchTerm, function(treeStructure) {
         document.getElementById("treant-container").innerHTML = "";
 
-        isKnowledgeExtractedFromGit(getProjectKey(), function(isKnowledgeExtractedFromGit) {
+        conDecAPI.isKnowledgeExtractedFromGit(getProjectKey(), function(isKnowledgeExtractedFromGit) { //TODO: refactor isKnowledgeExtractedFromGit param name, confusing.
             if (isKnowledgeExtractedFromGit) {
-                getCommits(elementKey,
+                conDecAPI.getCommits(elementKey,
                     function(commits) {
                         if (commits.length > 0) {
                             treeStructure.nodeStructure.children = addCommits(commits,
@@ -127,7 +127,7 @@ function drop(event, target) {
 	var parentId = target.id;
 	var childId = dragId;
 	if (sentenceElementIsDropped(target, parentId, childId)) {
-		deleteLink(oldParentId, childId, function() {
+		conDecAPI.deleteLink(oldParentId, childId, function() {
 			createLinkToExistingElement(parentId, childId);
 		});
 	}
@@ -140,29 +140,29 @@ function sentenceElementIsDropped(target, parentId, childId) {
 	var newParentType = extractTypeFromHTMLElement(target);
 	// selected element is a sentence, dropped element is an issue
 	if (draggedElement.classList.contains("sentence") && !target.classList.contains("sentence")) {
-		deleteGenericLink(findParentId(draggedElement.id), draggedElement.id, oldParentType, sourceType, function() {
-			linkGenericElements(target.id, draggedElement.id, newParentType, sourceType, function() {
+		conDecAPI.deleteGenericLink(findParentId(draggedElement.id), draggedElement.id, oldParentType, sourceType, function() {
+			conDecAPI.linkGenericElements(target.id, draggedElement.id, newParentType, sourceType, function() {
 				updateView();
 			});
 		});
 	} else // selected element is an issue, dropped element is an sentence
 	if (target.classList.contains("sentence") && !draggedElement.classList.contains("sentence")) {
-		deleteLink("s"+oldParentId, "i"+childId, function() {
-			linkGenericElements(target.id, draggedElement.id, newParentType, sourceType, function() {
+		conDecAPI.deleteLink("s"+oldParentId, "i"+childId, function() {
+			conDecAPI.linkGenericElements(target.id, draggedElement.id, newParentType, sourceType, function() {
 				updateView();
 			});
 		});
 	} else // selected element is a sentence, dropped element is an sentence
 	if (target.classList.contains("sentence") && draggedElement.classList.contains("sentence")) {
-		deleteGenericLink(findParentId(draggedElement.id), draggedElement.id, oldParentType, sourceType, function() {
-			linkGenericElements(target.id, draggedElement.id, newParentType, sourceType, function() {
+		conDecAPI.deleteGenericLink(findParentId(draggedElement.id), draggedElement.id, oldParentType, sourceType, function() {
+			conDecAPI.linkGenericElements(target.id, draggedElement.id, newParentType, sourceType, function() {
 				updateView();
 			});
 		});
 	} else // selected element is an issue, parent element is a sentence
 	if (!draggedElement.classList.contains("sentence")
 			&& document.getElementById(findParentId(draggedElement.id)).classList.contains("sentence")) {
-		deleteGenericLink(findParentId(draggedElement.id), draggedElement.id, oldParentType, sourceType, function() {
+		conDecAPI.deleteGenericLink(findParentId(draggedElement.id), draggedElement.id, oldParentType, sourceType, function() {
 			createLinkToExistingElement(parentId, childId);
 		});
 	} else {// usual link between issue and issue

--- a/src/main/resources/js/view.tree.viewer.js
+++ b/src/main/resources/js/view.tree.viewer.js
@@ -6,7 +6,7 @@ function buildTreeViewer() {
 	console.log("view.tree.viewer.js buildTreeViewer");
 	resetTreeViewer();
 	var rootElementType = $("select[name='select-root-element-type']").val();
-	getTreeViewer(rootElementType, function(core) {
+	conDecAPI.getTreeViewer(rootElementType, function(core) {
 		jQueryConDec("#jstree").jstree({
 			"core" : core,
 			"plugins" : [ "dnd", "contextmenu", "wholerow", "sort", "search", "state" ],
@@ -95,13 +95,13 @@ function addDragAndDropSupportForTreeViewer() {
 			}
 			if (parentNode === "#" && oldParentNode !== "#") {
 
-				deleteLink(oldParentNode.data.id, nodeId, function() {
+				conDecAPI.deleteLink(oldParentNode.data.id, nodeId, function() {
 					updateView();
 				});
 			}
 			if (parentNode !== '#' && oldParentNode !== '#') {
 
-				deleteLink(oldParentNode.data.id, nodeId, function() {
+				conDecAPI.deleteLink(oldParentNode.data.id, nodeId, function() {
 					createLinkToExistingElement(parentNode.data.id, nodeId);
 				});
 			}
@@ -111,14 +111,14 @@ function addDragAndDropSupportForTreeViewer() {
 
 			if (oldParentNode === "#" && parentNode !== "#") {
 
-				linkGenericElements(parentNode.data.id, nodeId, targetType, "s", function() {
+				conDecAPI.linkGenericElements(parentNode.data.id, nodeId, targetType, "s", function() {
 					refreshTreeViewer();
 				});
 			}
 			if (parentNode === "#" && oldParentNode !== "#") {
 
 				targetTypeOld = (oldParentNode.li_attr['class'] === "sentence") ? "s" : "i";
-				deleteGenericLink(oldParentNode.data.id, nodeId, targetTypeOld, "s", function() {
+				conDecAPI.deleteGenericLink(oldParentNode.data.id, nodeId, targetTypeOld, "s", function() {
 					refreshTreeViewer()
 				});
 			}
@@ -127,14 +127,14 @@ function addDragAndDropSupportForTreeViewer() {
 				targetTypeOld = (oldParentNode.li_attr['class'] === "sentence") ? "s" : "i";
 				var nodeType = (node.li_attr['class'] === "sentence") ? "s" : "i";
 				if (nodeType == "i" && targetTypeOld == "i") {
-					deleteLink(oldParentNode.data.id, nodeId, function() {
-						linkGenericElements(parentNode.data.id, nodeId, targetType, nodeType, function() {
+					conDecAPI.deleteLink(oldParentNode.data.id, nodeId, function() {
+						conDecAPI.linkGenericElements(parentNode.data.id, nodeId, targetType, nodeType, function() {
 							refreshTreeViewer()
 						});
 					});
 				} else {
-					deleteGenericLink(oldParentNode.data.id, nodeId, targetTypeOld, nodeType, function() {
-						linkGenericElements(parentNode.data.id, nodeId, targetType, nodeType, function() {
+					conDecAPI.deleteGenericLink(oldParentNode.data.id, nodeId, targetTypeOld, nodeType, function() {
+						conDecAPI.linkGenericElements(parentNode.data.id, nodeId, targetType, nodeType, function() {
 							refreshTreeViewer()
 						});
 					});

--- a/src/main/resources/templates/decisionKnowledgePage.vm
+++ b/src/main/resources/templates/decisionKnowledgePage.vm
@@ -26,6 +26,15 @@ $webResourceManager.requireResource("de.uhd.ifi.se.decision.management.jira:deci
     <div id="treant-container" class="right"></div>
 </div>
 <script>
-    initializeDecisionKnowledgePage();
+/*
+instantiate the ConDecKnowledgePage object controlling this view
+*/
+$(document).ready(function(){
+    if ( window.conDecKnowledgePage.init(window,window,window,window,window,window) )
+        window.conDecKnowledgePage.fetchAndRender();
+    else {
+        console.error("ConDecKnowledgePage could not get its dependencies.");
+    }
+});
 </script>
 #include("templates/dialog.vm")

--- a/src/main/resources/templates/decisionKnowledgePage.vm
+++ b/src/main/resources/templates/decisionKnowledgePage.vm
@@ -30,7 +30,7 @@ $webResourceManager.requireResource("de.uhd.ifi.se.decision.management.jira:deci
 instantiate the ConDecKnowledgePage object controlling this view
 */
 $(document).ready(function(){
-    if ( window.conDecKnowledgePage.init(window,window,window,window,window,window) )
+    if ( window.conDecKnowledgePage.init(conDecAPI,window,window,window,window,window) )
         window.conDecKnowledgePage.fetchAndRender();
     else {
         console.error("ConDecKnowledgePage could not get its dependencies.");

--- a/src/main/resources/templates/issueModule.vm
+++ b/src/main/resources/templates/issueModule.vm
@@ -11,7 +11,7 @@ $webResourceManager.requireResource("de.uhd.ifi.se.decision.management.jira:issu
 instantiate the ConDecIssueModule object controlling this view
 */
 $(document).ready(function(){
-    if ( window.conDecIssueModule.init(window,window,window,window,window,window) )
+    if ( window.conDecIssueModule.init(conDecAPI,window,window,window,window,window) )
         window.conDecIssueModule.initView();
     else {
         console.error("ConDecIssueModule could not get its dependencies.");

--- a/src/main/resources/templates/issueModule.vm
+++ b/src/main/resources/templates/issueModule.vm
@@ -6,6 +6,15 @@ $webResourceManager.requireResource("de.uhd.ifi.se.decision.management.jira:issu
 	<p>No Element has been selected</p>
 </div>
 #include("templates/dialog.vm")
-<script>    
-	fillIssueModule();
+<script>
+/*
+instantiate the ConDecIssueModule object controlling this view
+*/
+$(document).ready(function(){
+    if ( window.conDecIssueModule.init(window,window,window,window,window,window) )
+        window.conDecIssueModule.initView();
+    else {
+        console.error("ConDecIssueModule could not get its dependencies.");
+    }
+});
 </script>

--- a/src/main/resources/templates/settingsForAllProjects.vm
+++ b/src/main/resources/templates/settingsForAllProjects.vm
@@ -66,7 +66,7 @@ $webResourceManager.requireResource("de.uhd.ifi.se.decision.management.jira:styl
 				var jiraPrivateKey = document.getElementById("privateKey");
 				var consumerKey = document.getElementById("consumerKey");
 				var projectKey = getProjectKey();
-                getRequestToken(projectKey, jiraBaseUrl.value, jiraPrivateKey.value, consumerKey.value, function(result) {
+                conDecAPI.getRequestToken(projectKey, jiraBaseUrl.value, jiraPrivateKey.value, consumerKey.value, function(result) {
                     this.busy = true;
                     document.getElementById("requestToken").value = result["result"];
                    	var url = jiraBaseUrl.value + "/plugins/servlet/oauth/authorize?oauth_token=" + result["result"];
@@ -85,7 +85,7 @@ $webResourceManager.requireResource("de.uhd.ifi.se.decision.management.jira:styl
 				var projectKey = getProjectKey();
 				var secret = document.getElementById("gitIntegration-secret");
 
-                getAccessToken(projectKey, jiraBaseUrl.value, jiraPrivateKey.value, consumerKey.value, 
+                conDecAPI.getAccessToken(projectKey, jiraBaseUrl.value, jiraPrivateKey.value, consumerKey.value, 
                 		requestToken.value, secret.value, function(result) {
                 	this.busy = true;
                 	console.log(result);
@@ -120,7 +120,7 @@ $webResourceManager.requireResource("de.uhd.ifi.se.decision.management.jira:styl
                             #end
                             toggle.addEventListener('change', function (error) {
                                 this.busy = true;
-                                setActivated(this.checked, this.value);
+                                conDecAPI.setActivated(this.checked, this.value);
                                 this.busy = false;
                             });
                         });
@@ -137,7 +137,7 @@ $webResourceManager.requireResource("de.uhd.ifi.se.decision.management.jira:styl
                             #end
                             toggle.addEventListener('change', function (e) {
                                 this.busy = true;
-                                setIssueStrategy(this.checked, this.value);
+                                conDecAPI.setIssueStrategy(this.checked, this.value);
                                 this.busy = false;
                             });
                         });
@@ -156,7 +156,7 @@ $webResourceManager.requireResource("de.uhd.ifi.se.decision.management.jira:styl
                             #end
                             toggle.addEventListener('change', function (error) {
                                 this.busy = true;
-                                setKnowledgeExtractedFromGit(this.checked, this.value);
+                                conDecAPI.setKnowledgeExtractedFromGit(this.checked, this.value);
                                 this.busy = false;
                             });
                         });
@@ -175,7 +175,7 @@ $webResourceManager.requireResource("de.uhd.ifi.se.decision.management.jira:styl
                             #end
                             toggle.addEventListener('change', function (error) {
                                 this.busy = true;
-                                setKnowledgeExtractedFromIssues(this.checked, this.value);
+                                conDecAPI.setKnowledgeExtractedFromIssues(this.checked, this.value);
                                 this.busy = false;
                             });
                         });

--- a/src/main/resources/templates/settingsForSingleProject.vm
+++ b/src/main/resources/templates/settingsForSingleProject.vm
@@ -104,7 +104,7 @@ $webResourceManager.requireResource("de.uhd.ifi.se.decision.management.jira:styl
 			classifyAllIssuesInProjectButton.addEventListener("click", function() {
 				if (confirm('Are you sure you want to classify all issue comments? This might take some time if the project is big.')) {
 					AJS.progressBars.setIndeterminate("#progress-bar");
-	        		var isSucceeded = classifyWholeProject('$projectKey'); 
+	        		var isSucceeded = conDecAPI.classifyWholeProject('$projectKey'); 
 	        		AJS.progressBars.update("#progress-bar", isSucceeded);               		
 	        	}
 	    	});
@@ -139,7 +139,7 @@ $webResourceManager.requireResource("de.uhd.ifi.se.decision.management.jira:styl
 	<div class="field-group">
 		<label for="webhook-type">Root Element Type:</label>
 		<select id="webook-type" name="webhook-type" class="select medium-field" 
-				onchange="setWebhookType(this.options[this.selectedIndex].value, '$projectKey')"></select>
+				onchange="conDecAPI.setWebhookType(this.options[this.selectedIndex].value, '$projectKey')"></select>
 		#foreach ($issueType in $issueTypes) 
 			<script>
 				var isSelected = "";
@@ -196,7 +196,7 @@ $webResourceManager.requireResource("de.uhd.ifi.se.decision.management.jira:styl
 	
 	var clearSentenceDatabaseButton = document.getElementById("validateSentenceDatabase");
 	clearSentenceDatabaseButton.addEventListener("click", function() {
-		clearSentenceDatabase('$projectKey');
+		conDecAPI.clearSentenceDatabase('$projectKey');
 	});
 	
 	var sentenceIconToggle = document.getElementById('iconParsing-toggle');
@@ -224,19 +224,19 @@ $webResourceManager.requireResource("de.uhd.ifi.se.decision.management.jira:styl
 	webHookSubmit.addEventListener("click", function() {
 		var urlInput = document.getElementById("webhook-url");
 		var secretInput = document.getElementById("webhook-secret");
-		setWebhookData('$projectKey', urlInput.value, secretInput.value);
+		conDecAPI.setWebhookData('$projectKey', urlInput.value, secretInput.value);
 		window.onbeforeunload = null;
 	});
 	
 	activationToggle.addEventListener('change', function(error) {
 		this.busy = true;
-		setActivated(this.checked, this.value);
+		conDecAPI.setActivated(this.checked, this.value);
 		this.busy = false;
 	});
 	
 	strategyToggle.addEventListener('change', function(error) {
 		this.busy = true;
-		setIssueStrategy(this.checked, this.value);
+		conDecAPI.setIssueStrategy(this.checked, this.value);
 		this.busy = false;
 	});
 	
@@ -247,38 +247,38 @@ $webResourceManager.requireResource("de.uhd.ifi.se.decision.management.jira:styl
 		});
 	    typeToggles[j].addEventListener('change', function (error) {
 	        this.busy = true;
-	        setKnowledgeTypeEnabled(this.checked, this.value, '$projectKey');
+	        conDecAPI.setKnowledgeTypeEnabled(this.checked, this.value, '$projectKey');
 	        this.busy = false;
 	    });           
 	}
 	
 	issueCommentsToggle.addEventListener('change', function(error) {
 		this.busy = true;
-		setKnowledgeExtractedFromIssues(this.checked, this.value);
+		conDecAPI.setKnowledgeExtractedFromIssues(this.checked, this.value);
 		this.busy = false;
 	});
 	
 	isClassifierUsedToggle.addEventListener('change', function(error) {
 		this.busy = true;
-		setUseClassiferForIssueComments(this.checked, this.value);
+		conDecAPI.setUseClassiferForIssueComments(this.checked, this.value);
 		this.busy = false;
 	});
 	
 	sentenceIconToggle.addEventListener('change', function(error) {
 		this.busy = true;
-		setIconParsing(this.value, this.checked);
+		conDecAPI.setIconParsing(this.value, this.checked);
 		this.busy = false;
 	});
 	
 	gitToggle.addEventListener('change', function(error) {
 		this.busy = true;
-		setKnowledgeExtractedFromGit(this.checked, this.value);
+		conDecAPI.setKnowledgeExtractedFromGit(this.checked, this.value);
 		this.busy = false;
 	});
 	
 	webhookToggle.addEventListener('change', function(error) {
 		this.busy = true;
-		setWebhookEnabled(this.checked, this.value);
+		conDecAPI.setWebhookEnabled(this.checked, this.value);
 		this.busy = false;
 	});
 </script>

--- a/src/main/resources/templates/tabPanel.vm
+++ b/src/main/resources/templates/tabPanel.vm
@@ -59,7 +59,7 @@ $webResourceManager.requireResource("de.uhd.ifi.se.decision.management.jira:clas
 instantiate the ConDecIssueTab object controlling this view
 */
 $(document).ready(function(){
-    if (! window.conDecIssueTab.init(window,window,window) ) {
+    if (! window.conDecIssueTab.init(conDecAPI,window,window) ) {
         console.error("ConDecIssueTab could not get its dependencies.");
     }
 });

--- a/src/main/resources/templates/tabPanel.vm
+++ b/src/main/resources/templates/tabPanel.vm
@@ -54,3 +54,13 @@ $webResourceManager.requireResource("de.uhd.ifi.se.decision.management.jira:clas
 	</div> 
 </div>
 #end
+<script>
+/*
+instantiate the ConDecIssueTab object controlling this view
+*/
+$(document).ready(function(){
+    if (! window.conDecIssueTab.init(window,window,window) ) {
+        console.error("ConDecIssueTab could not get its dependencies.");
+    }
+});
+</script>


### PR DESCRIPTION
Hi @kleebaum , @dekome , @Jcl15 , @larstralle , @ematios,

with this branch the javascript code got cleaned up a bit. Previously the window object was 'polluted' with numerous functions, functions which at times had identical names across .js files.

For following files object instances were created:
* view.issue.module.js functions are now part of the **conDecIssueModule** object
    * for this file I skipped transformations for "ExportAsTable"-related code. It should still, but there is a chance it might not work.
* view.decision.knowledge.page.js functions are now part of the **conDecKnowledgePage** object
* view.issue.tab.panel.js functions are now part of the **conDecIssueTab** object
* rest.client.js functions are now part of the **conDecAPI** object

Some of these object methods/functions are now just private, but most are still publically accessible.

This had impact also on all our .vm files.

Because of the soon release, I decided not to work on restructing the less problemeatic files, which are:
* view.context.menu.js
* view.treant.js
* view.tree.viewer.js.

these files were of course affected by the transformations in this branch too.

Merging my changes with develop branch will also take some pain and effort anyway. I cannot do the merge, someone else has to do it.

Best regards
Lukasz

Ps. I checked my changes and I did not see that I have broken anything, after the merge the complete system still has to be checked by someone. In general I have seen that with the introduction of new dialogs (like for the export feature) some duplicate HTML id-Attributes were introduced, which breaks the functionality of some buttons in the dialog.