### PR TITLE
ConDec-437: Fix that dialog stays empty

### DIFF
--- a/src/main/resources/templates/jiraIssueModule.vm
+++ b/src/main/resources/templates/jiraIssueModule.vm
@@ -13,7 +13,7 @@ if (dialog) {
 var exportDialog = document.getElementById("export-dialog");
 if (exportDialog) {
 	console.log("export dialog exists");
-	//exportDialog.parentNode.removeChild(exportDialog);
+	exportDialog.parentNode.removeChild(exportDialog);
 }
 </script>
 #include("templates/dialog.vm")

--- a/src/main/resources/templates/jiraIssueModule.vm
+++ b/src/main/resources/templates/jiraIssueModule.vm
@@ -4,6 +4,18 @@ $webResourceManager.requireResource("de.uhd.ifi.se.decision.management.jira:jira
 <div id="treant-container">
 	<p>No Element has been selected</p>
 </div>
+<script>
+var dialog = document.getElementById("dialog");
+if (dialog) {
+	console.log("dialog exists");
+	dialog.parentNode.removeChild(dialog);
+}
+var exportDialog = document.getElementById("export-dialog");
+if (exportDialog) {
+	console.log("export dialog exists");
+	//exportDialog.parentNode.removeChild(exportDialog);
+}
+</script>
 #include("templates/dialog.vm")
 #include("templates/contextMenu.vm")
 <script>


### PR DESCRIPTION
When the JIRA.trigger method is called, the #include("templates/dialog.vm") in the jiraIssueModule.vm is called again. Thus, the dialog is included twice and the id is not unique anymore.