### PR TITLE
ConDec-483: fix resource build handler resolution for AMPS 8+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
 		<plugins>
 			<plugin>
 				<groupId>com.atlassian.maven.plugins</groupId>
-				<artifactId>maven-jira-plugin</artifactId>
+				<artifactId>jira-maven-plugin</artifactId>
 				<version>${amps.version}</version>
 				<extensions>true</extensions>
 				<configuration>
@@ -255,7 +255,6 @@
 					<productVersion>${jira.version}</productVersion>
 					<productDataVersion>${jira.version}</productDataVersion>
 					<enableQuickReload>true</enableQuickReload>
-					<enableFastdev>false</enableFastdev>
 					<instructions>
 						<Atlassian-Plugin-Key>${atlassian.plugin.key}</Atlassian-Plugin-Key>
 						<Import-Package> org.springframework.osgi.*;resolution:="optional",
@@ -305,7 +304,7 @@
 	</build>
 	<properties>
 		<jira.version>8.1.0</jira.version>
-		<amps.version>6.3.20</amps.version>		
+		<amps.version>8.0.1</amps.version>
 		<ao.version>1.5.0</ao.version>
 		<plugin.testrunner.version>2.0.1</plugin.testrunner.version>
 		<atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -78,7 +78,7 @@
 		</description>
 		<context>jira.view.issue</context>
 		<!-- jquery 1.9.1 for the plug-in (required by jstree) with Sizzle -->
-		<resource type="download" name="jqueryConDec" location="/js/jquery/jquery.js" />
+		<resource type="download" name="jqueryConDec.js" location="/js/jquery/jquery.js" />
 		<!-- jstree -->
 		<resource type="download" name="jstree.js" location="/js/jstree/jstree.js" />
 		<!-- treant -->


### PR DESCRIPTION
* apparently resolution of resource handlers during plugin build process is done based on the extension of the name attribute in atlassian-plugin.xml resource tags. Adding .js to the name solves the issue observed for AMPS version 8. Without this change the YUI compiler will not be used for the /js/jquery/jquery.js
* switched the project to use AMPS 8.0.1, which requires developers to have the appropriate atlassian SDK installed. See pom.xml
    * com.atlassian.maven.plugins changed its artifactID with SDK 8
    * also removed enableFastdev as it is not supported any more