### PR TITLE
ConDec-499: Improve logging, remove system.out.println and system.err.println

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.6.6</version>
+			<version>1.7.25</version>
 			<scope>provided</scope>
 		</dependency>
 		<!-- Active Objects -->

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/config/AbstractSettingsServlet.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/config/AbstractSettingsServlet.java
@@ -64,7 +64,7 @@ public abstract class AbstractSettingsServlet extends HttpServlet {
 		response.sendRedirect(
 				ComponentAccessor.getApplicationProperties().getString(APKeys.JIRA_BASEURL) + "/login.jsp");
 		LOGGER.info("User with name('{}') tried to change the project settings and was redirected to login.",
-				AuthenticationManager.getUsername(request)
+				AuthenticationManager.getUsername(request));
 	}
 
 	protected abstract String getTemplatePath();

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/config/AbstractSettingsServlet.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/config/AbstractSettingsServlet.java
@@ -64,7 +64,7 @@ public abstract class AbstractSettingsServlet extends HttpServlet {
 		response.sendRedirect(
 				ComponentAccessor.getApplicationProperties().getString(APKeys.JIRA_BASEURL) + "/login.jsp");
 		LOGGER.info("User with name('{}') tried to change the project settings and was redirected to login.",
-				AuthenticationManager.getUsername(request));
+				AuthenticationManager.getUsername(request)
 	}
 
 	protected abstract String getTemplatePath();

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/extraction/ClassificationManagerForJiraIssueComments.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/extraction/ClassificationManagerForJiraIssueComments.java
@@ -31,7 +31,6 @@ public class ClassificationManagerForJiraIssueComments {
 		if (issue == null) {
 			return;
 		}
-		// TODO
 	}
 
 	public void classifyAllCommentsOfJiraIssue(Issue issue) {

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/extraction/ClassificationTrainer.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/extraction/ClassificationTrainer.java
@@ -11,6 +11,8 @@ import java.util.List;
 import de.uhd.ifi.se.decision.management.jira.ComponentGetter;
 import de.uhd.ifi.se.decision.management.jira.extraction.impl.ClassificationTrainerImpl;
 import de.uhd.ifi.se.decision.management.jira.model.DecisionKnowledgeElement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import weka.core.Instances;
 
 /**
@@ -21,6 +23,7 @@ public interface ClassificationTrainer {
 
 	public static final File DEFAULT_TRAINING_DATA = new File(DecisionKnowledgeClassifier.DEFAULT_DIR + "lucene.arff");
 
+	static final Logger LOGGER = LoggerFactory.getLogger(ClassificationTrainer.class);
 	/**
 	 * Trains the Classifier with the Data from the Database that was set and
 	 * validated from the user. Creates a new model Files that can be uses to
@@ -113,7 +116,7 @@ public interface ClassificationTrainer {
 	 */
 	public static boolean trainClassifier(File arffFile) {
 		if (!arffFile.exists()) {
-			System.err.println("Could not find default training data for supervised text classifier.");
+			LOGGER.error("Could not find default training data for supervised text classifier.");
 			return false;
 		}
 		ClassificationTrainer classificationTrainer = new ClassificationTrainerImpl();
@@ -143,7 +146,7 @@ public interface ClassificationTrainer {
 			outputStream.write(buffer);
 			outputStream.close();
 		} catch (IOException e) {
-			e.printStackTrace();
+			LOGGER.error("Failed to copy default training data to file. Message: " + e.getMessage());
 		}
 		return arffFile;
 	}

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/extraction/DecXtractEventListener.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/extraction/DecXtractEventListener.java
@@ -201,7 +201,7 @@ public class DecXtractEventListener implements InitializingBean, DisposableBean 
 				changedString.put(oldValue, newValue);
 			}
 		} catch (NullPointerException | GenericEntityException e) {
-			LOGGER.error("Get changed string in a issue event failed. Message: " + e.getMessage());
+			LOGGER.error("Get changed string during a JIRA issue event failed. Message: " + e.getMessage());
 		}
 
 		return changedString;

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/extraction/DecXtractEventListener.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/extraction/DecXtractEventListener.java
@@ -201,7 +201,7 @@ public class DecXtractEventListener implements InitializingBean, DisposableBean 
 				changedString.put(oldValue, newValue);
 			}
 		} catch (NullPointerException | GenericEntityException e) {
-			e.printStackTrace();
+			LOGGER.error("Get changed string in a issue event failed. Message: " + e.getMessage());
 		}
 
 		return changedString;

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/extraction/DecisionKnowledgeClassifier.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/extraction/DecisionKnowledgeClassifier.java
@@ -3,13 +3,14 @@ package de.uhd.ifi.se.decision.management.jira.extraction;
 import java.io.File;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.atlassian.jira.component.ComponentAccessor;
 import com.atlassian.jira.config.util.JiraHome;
 
 import de.uhd.ifi.se.decision.management.jira.model.KnowledgeType;
 import meka.classifiers.multilabel.LC;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import weka.classifiers.meta.FilteredClassifier;
 import weka.core.tokenizers.NGramTokenizer;
 import weka.core.tokenizers.Tokenizer;
@@ -28,7 +29,6 @@ public interface DecisionKnowledgeClassifier {
 	 */
 	public static final String DEFAULT_DIR = ComponentAccessor.getComponentOfType(JiraHome.class).getDataDirectory()
 			.getAbsolutePath() + File.separator + "condec-plugin" + File.separator + "classifier" + File.separator;
-
 
 	static final Logger LOGGER = LoggerFactory.getLogger(DecisionKnowledgeClassifier.class);
 
@@ -100,7 +100,7 @@ public interface DecisionKnowledgeClassifier {
 					"weka.core.tokenizers.NGramTokenizer -max 3 -min 1 -delimiters \" \\r\\n\\t.,;:\\'\\\"()?!\"");
 			tokenizer.setOptions(options);
 		} catch (Exception e) {
-			LOGGER.error("Failed to get the Tokenizer. Message: " + e.getMessage());
+			LOGGER.error("Failed to get the tokenizer. Message: " + e.getMessage());
 		}
 		return tokenizer;
 	}

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/extraction/DecisionKnowledgeClassifier.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/extraction/DecisionKnowledgeClassifier.java
@@ -8,6 +8,8 @@ import com.atlassian.jira.config.util.JiraHome;
 
 import de.uhd.ifi.se.decision.management.jira.model.KnowledgeType;
 import meka.classifiers.multilabel.LC;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import weka.classifiers.meta.FilteredClassifier;
 import weka.core.tokenizers.NGramTokenizer;
 import weka.core.tokenizers.Tokenizer;
@@ -26,6 +28,9 @@ public interface DecisionKnowledgeClassifier {
 	 */
 	public static final String DEFAULT_DIR = ComponentAccessor.getComponentOfType(JiraHome.class).getDataDirectory()
 			.getAbsolutePath() + File.separator + "condec-plugin" + File.separator + "classifier" + File.separator;
+
+
+	static final Logger LOGGER = LoggerFactory.getLogger(DecisionKnowledgeClassifier.class);
 
 	/**
 	 * Determines for a list of strings whether each string is relevant decision
@@ -95,7 +100,7 @@ public interface DecisionKnowledgeClassifier {
 					"weka.core.tokenizers.NGramTokenizer -max 3 -min 1 -delimiters \" \\r\\n\\t.,;:\\'\\\"()?!\"");
 			tokenizer.setOptions(options);
 		} catch (Exception e) {
-			e.printStackTrace();
+			LOGGER.error("Failed to get the Tokenizer. Message: " + e.getMessage());
 		}
 		return tokenizer;
 	}

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/extraction/impl/ClassificationTrainerImpl.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/extraction/impl/ClassificationTrainerImpl.java
@@ -15,6 +15,8 @@ import de.uhd.ifi.se.decision.management.jira.extraction.DecisionKnowledgeClassi
 import de.uhd.ifi.se.decision.management.jira.model.DecisionKnowledgeElement;
 import de.uhd.ifi.se.decision.management.jira.persistence.JiraIssueTextPersistenceManager;
 import meka.classifiers.multilabel.LC;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import weka.classifiers.Evaluation;
 import weka.classifiers.bayes.NaiveBayesMultinomial;
 import weka.classifiers.meta.FilteredClassifier;
@@ -36,6 +38,8 @@ public class ClassificationTrainerImpl implements ClassificationTrainer {
 	private File directory;
 	private Instances instances;
 	private DecisionKnowledgeClassifier classifier;
+
+	protected static final Logger LOGGER = LoggerFactory.getLogger(ClassificationTrainerImpl.class);
 
 	public ClassificationTrainerImpl() {
 		this.directory = new File(DecisionKnowledgeClassifier.DEFAULT_DIR);
@@ -72,7 +76,7 @@ public class ClassificationTrainerImpl implements ClassificationTrainer {
 				instances.setClassIndex(instances.numAttributes() - 1);
 			}
 		} catch (Exception e) {
-			e.printStackTrace();
+			LOGGER.error("Problem to get the Instances from Arff File. Message:" +e.getMessage());
 		}
 		return instances;
 	}
@@ -109,7 +113,7 @@ public class ClassificationTrainerImpl implements ClassificationTrainer {
 
 			isTrained = true;
 		} catch (Exception e) {
-			e.printStackTrace();
+			LOGGER.error("Problem training the Classifiers. Message:" +e.getMessage());
 		}
 		return isTrained;
 	}
@@ -124,8 +128,8 @@ public class ClassificationTrainerImpl implements ClassificationTrainer {
 		datarandom.stratify(folds);
 		rate.crossValidateModel(binaryRelevance, instances, folds, seed);
 
-		System.out.println(rate.toSummaryString());
-		System.out.println("Structure num classes: " + instances.numClasses());
+		LOGGER.info(rate.toSummaryString());
+		LOGGER.info("Structure num classes: " + instances.numClasses());
 
 		// for (int i = 0; i < instances.numClasses(); i++) {
 		// System.out.println(rate.fMeasure(i));
@@ -143,7 +147,7 @@ public class ClassificationTrainerImpl implements ClassificationTrainer {
 			writer.println(arffString);
 			writer.close();
 		} catch (IOException e) {
-			e.printStackTrace();
+			LOGGER.error("Problem saving Arff File. Message: "+ e.getMessage());
 		}
 		return arffFile;
 	}

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/extraction/impl/ClassificationTrainerImpl.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/extraction/impl/ClassificationTrainerImpl.java
@@ -76,7 +76,7 @@ public class ClassificationTrainerImpl implements ClassificationTrainer {
 				instances.setClassIndex(instances.numAttributes() - 1);
 			}
 		} catch (Exception e) {
-			LOGGER.error("Problem to get the Instances from Arff File. Message:" +e.getMessage());
+			LOGGER.error("Problem to get the instances from ARFF file. Message:" + e.getMessage());
 		}
 		return instances;
 	}
@@ -113,7 +113,7 @@ public class ClassificationTrainerImpl implements ClassificationTrainer {
 
 			isTrained = true;
 		} catch (Exception e) {
-			LOGGER.error("Problem training the Classifiers. Message:" +e.getMessage());
+			LOGGER.error("The classifier could not be trained. Message:" + e.getMessage());
 		}
 		return isTrained;
 	}
@@ -147,7 +147,7 @@ public class ClassificationTrainerImpl implements ClassificationTrainer {
 			writer.println(arffString);
 			writer.close();
 		} catch (IOException e) {
-			LOGGER.error("Problem saving Arff File. Message: "+ e.getMessage());
+			LOGGER.error("The ARFF file could not be saved. Message: " + e.getMessage());
 		}
 		return arffFile;
 	}

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/extraction/impl/ClassificationTrainerImpl.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/extraction/impl/ClassificationTrainerImpl.java
@@ -66,6 +66,9 @@ public class ClassificationTrainerImpl implements ClassificationTrainer {
 	}
 
 	private Instances getInstancesFromArffFile(File arffFile) {
+		if (!arffFile.exists()) {
+			return null;
+		}
 		Instances instances = null;
 		try {
 			DataSource dataSource = new ConverterUtils.DataSource(arffFile.getPath());
@@ -82,7 +85,9 @@ public class ClassificationTrainerImpl implements ClassificationTrainer {
 	}
 
 	private Instances getInstancesFromArffFile(String arffFileName) {
-		return getInstancesFromArffFile(new File(directory + File.separator + arffFileName));
+		File arffFile = new File(directory + File.separator + arffFileName);
+
+		return getInstancesFromArffFile(arffFile);
 	}
 
 	public void setArffFile(File arffFile) {

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/extraction/impl/DecisionKnowledgeClassifierImpl.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/extraction/impl/DecisionKnowledgeClassifierImpl.java
@@ -5,12 +5,13 @@ import java.io.FileInputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import de.uhd.ifi.se.decision.management.jira.extraction.ClassificationTrainer;
 import de.uhd.ifi.se.decision.management.jira.extraction.DecisionKnowledgeClassifier;
 import de.uhd.ifi.se.decision.management.jira.model.KnowledgeType;
 import meka.classifiers.multilabel.LC;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import weka.classifiers.meta.FilteredClassifier;
 import weka.core.Attribute;
 import weka.core.DenseInstance;
@@ -57,7 +58,7 @@ public class DecisionKnowledgeClassifierImpl implements DecisionKnowledgeClassif
 			binaryClassifier = (FilteredClassifier) SerializationHelper.read(new FileInputStream(binaryClassifierFile));
 		} catch (Exception e) {
 			binaryClassifier = new FilteredClassifier();
-			LOGGER.info("Could not find binary classifier file. A new instance got created");
+			LOGGER.info("Could not find the binary classifier. A new instance was created.");
 		}
 		return binaryClassifier;
 	}
@@ -73,7 +74,7 @@ public class DecisionKnowledgeClassifierImpl implements DecisionKnowledgeClassif
 			fineGrainedClassifier = (LC) SerializationHelper.read(new FileInputStream(fineGrainedClassifierFile));
 		} catch (Exception e) {
 			fineGrainedClassifier = new LC();
-			LOGGER.info("Could not find fine grained classifier file.A new instance got created");
+			LOGGER.info("Could not find the fine grained classifier. A new instance was created.");
 		}
 		return fineGrainedClassifier;
 	}

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/extraction/impl/DecisionKnowledgeClassifierImpl.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/extraction/impl/DecisionKnowledgeClassifierImpl.java
@@ -9,6 +9,8 @@ import de.uhd.ifi.se.decision.management.jira.extraction.ClassificationTrainer;
 import de.uhd.ifi.se.decision.management.jira.extraction.DecisionKnowledgeClassifier;
 import de.uhd.ifi.se.decision.management.jira.model.KnowledgeType;
 import meka.classifiers.multilabel.LC;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import weka.classifiers.meta.FilteredClassifier;
 import weka.core.Attribute;
 import weka.core.DenseInstance;
@@ -26,6 +28,8 @@ public class DecisionKnowledgeClassifierImpl implements DecisionKnowledgeClassif
 
 	private FilteredClassifier binaryClassifier;
 	private LC fineGrainedClassifier;
+
+	protected static final Logger LOGGER = LoggerFactory.getLogger(DecisionKnowledgeClassifierImpl.class);
 
 	/**
 	 * The knowledge types need to be present in the weka classifier. They do not
@@ -53,6 +57,7 @@ public class DecisionKnowledgeClassifierImpl implements DecisionKnowledgeClassif
 			binaryClassifier = (FilteredClassifier) SerializationHelper.read(new FileInputStream(binaryClassifierFile));
 		} catch (Exception e) {
 			binaryClassifier = new FilteredClassifier();
+			LOGGER.info("Could not find binary classifier file. A new instance got created");
 		}
 		return binaryClassifier;
 	}
@@ -68,6 +73,7 @@ public class DecisionKnowledgeClassifierImpl implements DecisionKnowledgeClassif
 			fineGrainedClassifier = (LC) SerializationHelper.read(new FileInputStream(fineGrainedClassifierFile));
 		} catch (Exception e) {
 			fineGrainedClassifier = new LC();
+			LOGGER.info("Could not find fine grained classifier file.A new instance got created");
 		}
 		return fineGrainedClassifier;
 	}
@@ -133,7 +139,7 @@ public class DecisionKnowledgeClassifierImpl implements DecisionKnowledgeClassif
 				binaryPredictionResults.add(isRelevant(predictionResult));
 			}
 		} catch (Exception e) {
-			System.err.println("Binary classification failed.");
+			LOGGER.error("Binary classification failed. Message: " + e.getMessage());
 			return new ArrayList<Boolean>();
 		}
 
@@ -172,8 +178,7 @@ public class DecisionKnowledgeClassifierImpl implements DecisionKnowledgeClassif
 				fineGrainedPredictionResults.add(getType(predictionResult));
 			}
 		} catch (Exception e) {
-			e.printStackTrace();
-			System.err.println(e.getStackTrace() + "Fine grained classification failed.");
+			LOGGER.error("Fine grained classification failed. Message: " + e.getMessage());
 			return null;
 		}
 

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/extraction/impl/GitClientImpl.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/extraction/impl/GitClientImpl.java
@@ -215,7 +215,7 @@ public class GitClientImpl implements GitClient {
 			parentCommit = revWalk.parseCommit(revCommit.getParent(0).getId());
 			revWalk.close();
 		} catch (Exception e) {
-			System.err.println("Could not get the parent commit. Message: " + e.getMessage());
+			LOGGER.error("Could not get the parent commit. Message: " + e.getMessage());
 		}
 		return parentCommit;
 	}

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/extraction/impl/GitClientImpl.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/extraction/impl/GitClientImpl.java
@@ -101,7 +101,8 @@ public class GitClientImpl implements GitClient {
 			git = Git.cloneRepository().setURI(uri).setDirectory(directory).setCloneAllBranches(true).call();
 			setConfig();
 		} catch (GitAPIException e) {
-			LOGGER.error("Git repository could not be cloned. Bare repository will be created. Message: " + e.getMessage());
+			LOGGER.error(
+					"Git repository could not be cloned. Bare repository will be created. Message: " + e.getMessage());
 			initRepository(directory);
 		}
 	}
@@ -301,24 +302,25 @@ public class GitClientImpl implements GitClient {
 		try {
 			refs = git.branchList().setListMode(ListBranchCommand.ListMode.ALL).call();
 		} catch (GitAPIException e) {
-			LOGGER.error("Git could not get all Refs. Message: " + e.getMessage());
+			LOGGER.error("Git could not get all references. Message: " + e.getMessage());
 		}
 		return refs;
 	}
 
 	private List<RevCommit> getCommits(Ref branch) {
 		List<RevCommit> commits = new ArrayList<RevCommit>();
+		if (branch == null) {
+			return commits;
+		}
 		try {
-			if (branch != null) {
-				git.checkout().setName(branch.getName()).call();
-			}
+			git.checkout().setName(branch.getName()).call();
 			Iterable<RevCommit> iterable = git.log().call();
 			for (RevCommit commit : iterable) {
 				commits.add(commit);
 			}
 		} catch (GitAPIException e) {
-			LOGGER.error("Git could not get Commits for the branch: "+ branch.getName() + " Message: "+
-					e.getMessage());
+			LOGGER.error(
+					"Git could not get commits for the branch: " + branch.getName() + " Message: " + e.getMessage());
 		}
 		return commits;
 	}

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/extraction/impl/GitClientImpl.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/extraction/impl/GitClientImpl.java
@@ -76,8 +76,7 @@ public class GitClientImpl implements GitClient {
 		try {
 			git = Git.open(directory);
 		} catch (IOException e) {
-			e.printStackTrace();
-			LOGGER.error("Git repository could not be opened.");
+			LOGGER.error("Git repository could not be opened. Message: " + e.getMessage());
 			initRepository(directory);
 		}
 	}
@@ -90,7 +89,7 @@ public class GitClientImpl implements GitClient {
 				git.fetch().setRemote(remote.getName()).setRefSpecs(remote.getFetchRefSpecs()).call();
 			}
 		} catch (GitAPIException e) {
-			e.printStackTrace();
+			LOGGER.error("Git repository could not be pulled. Message: " + e.getMessage());
 		}
 	}
 
@@ -102,8 +101,7 @@ public class GitClientImpl implements GitClient {
 			git = Git.cloneRepository().setURI(uri).setDirectory(directory).setCloneAllBranches(true).call();
 			setConfig();
 		} catch (GitAPIException e) {
-			e.printStackTrace();
-			LOGGER.error("Git repository could not be cloned. Bare repository will be created.");
+			LOGGER.error("Git repository could not be cloned. Bare repository will be created. Message: " + e.getMessage());
 			initRepository(directory);
 		}
 	}
@@ -112,7 +110,7 @@ public class GitClientImpl implements GitClient {
 		try {
 			git = Git.init().setDirectory(directory).call();
 		} catch (IllegalStateException | GitAPIException e) {
-			e.printStackTrace();
+			LOGGER.error("Git repository could not be initialized. Message: " + e.getMessage());
 		}
 	}
 
@@ -126,7 +124,7 @@ public class GitClientImpl implements GitClient {
 		try {
 			config.save();
 		} catch (IOException e) {
-			e.printStackTrace();
+			LOGGER.error("Git configuration could not be set. Message: " + e.getMessage());
 		}
 	}
 
@@ -159,7 +157,7 @@ public class GitClientImpl implements GitClient {
 				diffEntries = diffFormatter.scan(parentCommit.getTree(), lastCommit.getTree());
 			}
 		} catch (IOException e) {
-			e.printStackTrace();
+			LOGGER.error("Git Diff could not be created. Message: " + e.getMessage());
 		}
 
 		for (DiffEntry diffEntry : diffEntries) {
@@ -167,7 +165,7 @@ public class GitClientImpl implements GitClient {
 				EditList editList = diffFormatter.toFileHeader(diffEntry).toEditList();
 				diffEntriesMappedToEditLists.put(diffEntry, editList);
 			} catch (IOException e) {
-				e.printStackTrace();
+				LOGGER.error("Git Diff could not be created. Message: " + e.getMessage());
 			}
 		}
 		diffFormatter.close();
@@ -216,8 +214,7 @@ public class GitClientImpl implements GitClient {
 			parentCommit = revWalk.parseCommit(revCommit.getParent(0).getId());
 			revWalk.close();
 		} catch (Exception e) {
-			System.err.println("Could not get the parent commit.");
-			e.printStackTrace();
+			System.err.println("Could not get the parent commit. Message: " + e.getMessage());
 		}
 		return parentCommit;
 	}
@@ -287,7 +284,7 @@ public class GitClientImpl implements GitClient {
 		List<Ref> refs = getAllRefs();
 		Ref branch = null;
 		for (Ref ref : refs) {
-			System.out.println(ref.getName());
+			LOGGER.info(ref.getName());
 			if (ref.getName().contains(jiraIssueKey)) {
 				return ref;
 			} else if (ref.getName().equalsIgnoreCase("refs/heads/develop")) {
@@ -304,7 +301,7 @@ public class GitClientImpl implements GitClient {
 		try {
 			refs = git.branchList().setListMode(ListBranchCommand.ListMode.ALL).call();
 		} catch (GitAPIException e) {
-			e.printStackTrace();
+			LOGGER.error("Git could not get all Refs. Message: " + e.getMessage());
 		}
 		return refs;
 	}
@@ -320,7 +317,8 @@ public class GitClientImpl implements GitClient {
 				commits.add(commit);
 			}
 		} catch (GitAPIException e) {
-			e.printStackTrace();
+			LOGGER.error("Git could not get Commits for the branch: "+ branch.getName() + " Message: "+
+					e.getMessage());
 		}
 		return commits;
 	}

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/extraction/impl/GitClientImpl.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/extraction/impl/GitClientImpl.java
@@ -158,7 +158,7 @@ public class GitClientImpl implements GitClient {
 				diffEntries = diffFormatter.scan(parentCommit.getTree(), lastCommit.getTree());
 			}
 		} catch (IOException e) {
-			LOGGER.error("Git Diff could not be created. Message: " + e.getMessage());
+			LOGGER.error("Git diff could not be retrieved. Message: " + e.getMessage());
 		}
 
 		for (DiffEntry diffEntry : diffEntries) {
@@ -166,7 +166,7 @@ public class GitClientImpl implements GitClient {
 				EditList editList = diffFormatter.toFileHeader(diffEntry).toEditList();
 				diffEntriesMappedToEditLists.put(diffEntry, editList);
 			} catch (IOException e) {
-				LOGGER.error("Git Diff could not be created. Message: " + e.getMessage());
+				LOGGER.error("Git diff for the file " + diffEntry.getNewPath() + " could not be retrieved. Message: " + e.getMessage());
 			}
 		}
 		diffFormatter.close();
@@ -285,7 +285,6 @@ public class GitClientImpl implements GitClient {
 		List<Ref> refs = getAllRefs();
 		Ref branch = null;
 		for (Ref ref : refs) {
-			LOGGER.info(ref.getName());
 			if (ref.getName().contains(jiraIssueKey)) {
 				return ref;
 			} else if (ref.getName().equalsIgnoreCase("refs/heads/develop")) {

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/filtering/GraphFiltering.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/filtering/GraphFiltering.java
@@ -202,7 +202,7 @@ public class GraphFiltering {
 				Date queryStartDate = calendar.getTime();
 				startTime = queryStartDate.getTime();
 			} catch (NumberFormatException e) {
-				LOGGER.error("The Date is not in Format yyyy-mm-dd");
+				LOGGER.error("The Date is not in Format yyyy-mm-dd. Message: " + e.getMessage());
 			}
 		} else if (time.matches("(-\\d+(.))")) {
 			long factor = 0;
@@ -214,7 +214,7 @@ public class GraphFiltering {
 			try {
 				queryTime = Long.parseLong(queryTimeString);
 			} catch (NumberFormatException e) {
-				LOGGER.error("No valid time given");
+				LOGGER.error("No valid time given. Message: " + e.getMessage());
 			}
 			startTime = currentDate - (queryTime * factor);
 		}
@@ -236,7 +236,7 @@ public class GraphFiltering {
 				Date queryEndDate = calendar.getTime();
 				endTime = queryEndDate.getTime();
 			} catch (NumberFormatException e) {
-				LOGGER.error("The Date is not in Format yyyy-mm-dd");
+				LOGGER.error("The Date is not in Format yyyy-mm-dd. Message: " + e.getMessage());
 			}
 		} else if (time.matches("-\\d+(.)+")) {
 			long factor;
@@ -248,7 +248,7 @@ public class GraphFiltering {
 			try {
 				queryTime = Long.parseLong(queryTimeString);
 			} catch (NumberFormatException e) {
-				LOGGER.error("No valid time given");
+				LOGGER.error("No valid time given. Message: " + e.getMessage());
 			}
 			endTime = currentDate - (queryTime * factor);
 		}
@@ -289,7 +289,7 @@ public class GraphFiltering {
 				filterId = Long.parseLong(filteredQuery, 10);
 				filterIsNumberCoded = true;
 			} catch (NumberFormatException n) {
-				// n.printStackTrace();
+				LOGGER.error("Produce results from query failed. Message: " + n.getMessage());
 			}
 			if (filterIsNumberCoded) {
 				finalQuery = queryFromFilterId(filterId);
@@ -321,6 +321,7 @@ public class GraphFiltering {
 				resultingIssues = JiraSearchServiceHelper.getJiraIssues(results);
 
 			} catch (SearchException e) {
+				LOGGER.error("Produce results from query failed. Message: " + e.getMessage());
 				e.printStackTrace();
 			}
 		} else {
@@ -385,6 +386,7 @@ public class GraphFiltering {
 		try {
 			searchResult = getSearchService().search(user, query, PagerFilter.getUnlimitedFilter());
 		} catch (SearchException e) {
+			LOGGER.error("Get Issues for this project failed. Message: " + e.getMessage());
 			return null;
 		}
 		return searchResult;

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/filtering/JiraSearchServiceHelper.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/filtering/JiraSearchServiceHelper.java
@@ -30,14 +30,16 @@ public class JiraSearchServiceHelper {
 			try {
 				newGetMethod = SearchResults.class.getMethod("getResults");
 			} catch (NoSuchMethodError | NoSuchMethodException | SecurityException e2) {
+				LOGGER.error("Get Jira issues failed. Message: " + e.getMessage());
 			}
+			LOGGER.error("Get Jira issues failed. Message: " + e.getMessage());
 		}
 
 		if (newGetMethod != null && searchResults != null) {
 			try {
 				jiraIssues.addAll((List<Issue>) newGetMethod.invoke(searchResults));
 			} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-				e.printStackTrace();
+				LOGGER.error("Get Jira issues failed. Message: " + e.getMessage());
 			}
 		} else {
 			LOGGER.error("SearchResults Service from JIRA NOT AVAILABLE (getIssue / getResults)");

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/filtering/JiraSearchServiceHelper.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/filtering/JiraSearchServiceHelper.java
@@ -30,16 +30,15 @@ public class JiraSearchServiceHelper {
 			try {
 				newGetMethod = SearchResults.class.getMethod("getResults");
 			} catch (NoSuchMethodError | NoSuchMethodException | SecurityException e2) {
-				LOGGER.error("Get Jira issues failed. Message: " + e.getMessage());
+				LOGGER.error("Getting JIRA issues failed. Message: " + e.getMessage());
 			}
-			LOGGER.error("Get Jira issues failed. Message: " + e.getMessage());
 		}
 
 		if (newGetMethod != null && searchResults != null) {
 			try {
 				jiraIssues.addAll((List<Issue>) newGetMethod.invoke(searchResults));
 			} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-				LOGGER.error("Get Jira issues failed. Message: " + e.getMessage());
+				LOGGER.error("Getting JIRA issues failed. Message: " + e.getMessage());
 			}
 		} else {
 			LOGGER.error("SearchResults Service from JIRA NOT AVAILABLE (getIssue / getResults)");

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/model/impl/LinkImpl.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/model/impl/LinkImpl.java
@@ -206,7 +206,7 @@ public class LinkImpl implements Link {
 		try {
 			return !sourceElement.getProject().getProjectKey().equals(destinationElement.getProject().getProjectKey());
 		} catch (NullPointerException e) {
-			LOGGER.error("is not Valid. Message: " + e.getMessage());
+			LOGGER.error("Link is not valid. Message: " + e.getMessage());
 			return false;
 		}
 	}

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/model/impl/LinkImpl.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/model/impl/LinkImpl.java
@@ -14,6 +14,8 @@ import de.uhd.ifi.se.decision.management.jira.model.Link;
 import de.uhd.ifi.se.decision.management.jira.model.LinkType;
 import de.uhd.ifi.se.decision.management.jira.persistence.AbstractPersistenceManager;
 import de.uhd.ifi.se.decision.management.jira.persistence.tables.LinkInDatabase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Model class for links between decision knowledge elements
@@ -24,6 +26,8 @@ public class LinkImpl implements Link {
 	private String type;
 	private DecisionKnowledgeElement sourceElement;
 	private DecisionKnowledgeElement destinationElement;
+
+	protected static final Logger LOGGER = LoggerFactory.getLogger(LinkImpl.class);
 
 	public LinkImpl() {
 	}
@@ -202,6 +206,7 @@ public class LinkImpl implements Link {
 		try {
 			return !sourceElement.getProject().getProjectKey().equals(destinationElement.getProject().getProjectKey());
 		} catch (NullPointerException e) {
+			LOGGER.error("is not Valid. Message: " + e.getMessage());
 			return false;
 		}
 	}

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/model/text/impl/PartOfJiraIssueTextImpl.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/model/text/impl/PartOfJiraIssueTextImpl.java
@@ -15,6 +15,8 @@ import de.uhd.ifi.se.decision.management.jira.model.text.PartOfJiraIssueText;
 import de.uhd.ifi.se.decision.management.jira.model.text.PartOfText;
 import de.uhd.ifi.se.decision.management.jira.model.text.TextSplitter;
 import de.uhd.ifi.se.decision.management.jira.persistence.tables.PartOfJiraIssueTextInDatabase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Model class for textual parts (substrings) of JIRA issue comments or the
@@ -24,6 +26,8 @@ import de.uhd.ifi.se.decision.management.jira.persistence.tables.PartOfJiraIssue
 public class PartOfJiraIssueTextImpl extends PartOfTextImpl implements PartOfJiraIssueText {
 
 	private long commentId;
+
+	protected static final Logger LOGGER = LoggerFactory.getLogger(PartOfJiraIssueTextImpl.class);
 
 	public PartOfJiraIssueTextImpl() {
 		super();
@@ -95,7 +99,7 @@ public class PartOfJiraIssueTextImpl extends PartOfTextImpl implements PartOfJir
 				text = text.substring(startSubstringCount);
 			}
 		} catch (NullPointerException | StringIndexOutOfBoundsException e) {
-			e.printStackTrace();
+			LOGGER.error("Constructor faild to create object of PartOfJiraIssueTextImpl. Message: " + e.getMessage());
 		}
 		if (text == null) {
 			text = "";

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/persistence/ActiveObjectPersistenceManager.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/persistence/ActiveObjectPersistenceManager.java
@@ -90,7 +90,7 @@ public class ActiveObjectPersistenceManager extends AbstractPersistenceManager {
 		try {
 			idAsString = key.split("-")[1];
 		} catch (ArrayIndexOutOfBoundsException e) {
-			LOGGER.error("Key cannot be split into the project key and id.");
+			LOGGER.error("Key cannot be split into the project key and id. Message: " + e.getMessage());
 		}
 		if (idAsString != null) {
 			long id = Long.parseLong(idAsString);

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/persistence/JiraIssuePersistenceManager.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/persistence/JiraIssuePersistenceManager.java
@@ -121,7 +121,7 @@ public class JiraIssuePersistenceManager extends AbstractPersistenceManager {
 					link.getDestinationElement().getId(), linkTypeId);
 			return issueLink.getId();
 		} catch (CreateException | NullPointerException e) {
-			LOGGER.error("Insertion of link into database failed.");
+			LOGGER.error("Insertion of link into database failed. Message: " + e.getMessage());
 		}
 		return 0;
 	}
@@ -191,6 +191,7 @@ public class JiraIssuePersistenceManager extends AbstractPersistenceManager {
 			issueIds = issueManager.getIssueIdsForProject(project.getId());
 		} catch (GenericEntityException | NullPointerException e) {
 			issueIds = new ArrayList<Long>();
+			LOGGER.error("Get decisionknowledgeelemtns failed. Message: " + e.getMessage());
 		}
 
 		for (long issueId : issueIds) {

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/persistence/JiraIssueTextPersistenceManager.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/persistence/JiraIssueTextPersistenceManager.java
@@ -549,7 +549,7 @@ public class JiraIssueTextPersistenceManager extends AbstractPersistenceManager 
 		try {
 			issueLinkManager.createIssueLink(element.getJiraIssueId(), issue.getId(), linkTypeId, (long) 0, user);
 		} catch (CreateException e) {
-			LOGGER.error("create Jira issue from sentence object failed. Message: " +e.getMessage());
+			LOGGER.error("Creating JIRA issue from part of text failed. Message: " + e.getMessage());
 			return null;
 		}
 
@@ -680,7 +680,7 @@ public class JiraIssueTextPersistenceManager extends AbstractPersistenceManager 
 		}
 		PartOfJiraIssueTextInDatabase[] databaseEntries = ACTIVE_OBJECTS.find(PartOfJiraIssueTextInDatabase.class,
 				Query.select().where("PROJECT_KEY = ? and VALIDATED = ?", projectKey, true));
-		
+
 		for (PartOfJiraIssueTextInDatabase databaseEntry : databaseEntries) {
 			PartOfJiraIssueText validatedPartOfText = new PartOfJiraIssueTextImpl(databaseEntry);
 			validatedPartsOfText.add(validatedPartOfText);

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/persistence/JiraIssueTextPersistenceManager.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/persistence/JiraIssueTextPersistenceManager.java
@@ -549,6 +549,7 @@ public class JiraIssueTextPersistenceManager extends AbstractPersistenceManager 
 		try {
 			issueLinkManager.createIssueLink(element.getJiraIssueId(), issue.getId(), linkTypeId, (long) 0, user);
 		} catch (CreateException e) {
+			LOGGER.error("create Jira issue from sentence object failed. Message: " +e.getMessage());
 			return null;
 		}
 

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/quality/CommentMetricCalculator.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/quality/CommentMetricCalculator.java
@@ -33,6 +33,8 @@ import de.uhd.ifi.se.decision.management.jira.model.text.PartOfJiraIssueText;
 import de.uhd.ifi.se.decision.management.jira.persistence.GenericLinkManager;
 import de.uhd.ifi.se.decision.management.jira.persistence.JiraIssueTextPersistenceManager;
 import de.uhd.ifi.se.decision.management.jira.view.treant.Node;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CommentMetricCalculator {
 
@@ -43,6 +45,8 @@ public class CommentMetricCalculator {
 	private List<Issue> jiraIssues;
 	private int absolutDepth;
 	private GitClient gitClient;
+
+	protected static final Logger LOGGER = LoggerFactory.getLogger(CommentMetricCalculator.class);
 
 	public CommentMetricCalculator(long projectId, ApplicationUser user, String jiraIssueTypeId) {
 		this.projectKey = ComponentAccessor.getProjectManager().getProjectObj(projectId).getKey();
@@ -63,6 +67,7 @@ public class CommentMetricCalculator {
 			searchResults = searchService.search(user, query, PagerFilter.getUnlimitedFilter());
 			jiraIssues = JiraSearchServiceHelper.getJiraIssues(searchResults);
 		} catch (SearchException e) {
+			LOGGER.error("Get Jira issues for project failed. Message: " + e.getMessage());
 		}
 		return jiraIssues;
 	}
@@ -74,7 +79,8 @@ public class CommentMetricCalculator {
 			try {
 				numberOfComments = ComponentAccessor.getCommentManager().getComments(jiraIssue).size();
 			} catch (NullPointerException e) {
-				// Jira issue does not exist
+				LOGGER.error("get number of comments for jira issues failed. no issues are contained. " +
+						"Message: " + e.getMessage());
 				numberOfComments = 0;
 			}
 			numberOfCommentsForJiraIssues.put(jiraIssue.getKey(), numberOfComments);

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/quality/CommentMetricCalculator.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/quality/CommentMetricCalculator.java
@@ -6,6 +6,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.atlassian.jira.bc.issue.search.SearchService;
 import com.atlassian.jira.component.ComponentAccessor;
 import com.atlassian.jira.issue.Issue;
@@ -33,8 +36,6 @@ import de.uhd.ifi.se.decision.management.jira.model.text.PartOfJiraIssueText;
 import de.uhd.ifi.se.decision.management.jira.persistence.GenericLinkManager;
 import de.uhd.ifi.se.decision.management.jira.persistence.JiraIssueTextPersistenceManager;
 import de.uhd.ifi.se.decision.management.jira.view.treant.Node;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class CommentMetricCalculator {
 
@@ -67,7 +68,7 @@ public class CommentMetricCalculator {
 			searchResults = searchService.search(user, query, PagerFilter.getUnlimitedFilter());
 			jiraIssues = JiraSearchServiceHelper.getJiraIssues(searchResults);
 		} catch (SearchException e) {
-			LOGGER.error("Get Jira issues for project failed. Message: " + e.getMessage());
+			LOGGER.error("Getting JIRA issues for project failed. Message: " + e.getMessage());
 		}
 		return jiraIssues;
 	}
@@ -79,8 +80,7 @@ public class CommentMetricCalculator {
 			try {
 				numberOfComments = ComponentAccessor.getCommentManager().getComments(jiraIssue).size();
 			} catch (NullPointerException e) {
-				LOGGER.error("get number of comments for jira issues failed. no issues are contained. " +
-						"Message: " + e.getMessage());
+				LOGGER.error("Getting number of comments for JIRA issues failed. Message: " + e.getMessage());
 				numberOfComments = 0;
 			}
 			numberOfCommentsForJiraIssues.put(jiraIssue.getKey(), numberOfComments);

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/rest/ConfigRest.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/rest/ConfigRest.java
@@ -63,7 +63,7 @@ public class ConfigRest {
 			setDefaultKnowledgeTypesEnabled(projectKey, isActivated);
 			return Response.ok(Status.ACCEPTED).build();
 		} catch (Exception e) {
-			LOGGER.error("Failed to activate the plug-in. Message: " + e.getMessage());
+			LOGGER.error("Failed to change plug-in activation. Message: " + e.getMessage());
 			return Response.status(Status.CONFLICT).build();
 		}
 	}
@@ -104,7 +104,7 @@ public class ConfigRest {
 			manageDefaultIssueTypes(projectKey, isIssueStrategy);
 			return Response.ok(Status.ACCEPTED).build();
 		} catch (Exception e) {
-			LOGGER.error("Failed to apply the issue strategy. Message: " + e.getMessage());
+			LOGGER.error("Failed to enable or disable the JIRA issue persistence strategy. Message: " + e.getMessage());
 			return Response.status(Status.CONFLICT).build();
 		}
 	}
@@ -140,7 +140,7 @@ public class ConfigRest {
 					Boolean.valueOf(isKnowledgeExtractedFromGit));
 			return Response.ok(Status.ACCEPTED).build();
 		} catch (Exception e) {
-			LOGGER.error("Failed to active the knowledge extraction from git. Message: " + e.getMessage());
+			LOGGER.error("Failed to enable or disable the knowledge extraction from git. Message: " + e.getMessage());
 			return Response.status(Status.CONFLICT).build();
 		}
 	}
@@ -179,7 +179,7 @@ public class ConfigRest {
 					Boolean.valueOf(isKnowledgeExtractedFromIssues));
 			return Response.ok(Status.ACCEPTED).build();
 		} catch (Exception e) {
-			LOGGER.error("Failed to activate the extraction of knowledge from issues. Message: " +  e.getMessage());
+			LOGGER.error("Failed to enable or disable the extraction of knowledge from JIRA issues. Message: " +  e.getMessage());
 			return Response.status(Status.CONFLICT).build();
 		}
 	}
@@ -263,7 +263,7 @@ public class ConfigRest {
 			ConfigPersistenceManager.setWebhookEnabled(projectKey, isActivated);
 			return Response.ok(Status.ACCEPTED).build();
 		} catch (Exception e) {
-			LOGGER.error("Failed to enable the Webhook. Message: " + e.getMessage());
+			LOGGER.error("Failed to enable or disable the webhook. Message: " + e.getMessage());
 			return Response.status(Status.CONFLICT).build();
 		}
 	}
@@ -285,7 +285,7 @@ public class ConfigRest {
 			ConfigPersistenceManager.setWebhookSecret(projectKey, webhookSecret);
 			return Response.ok(Status.ACCEPTED).build();
 		} catch (Exception e) {
-			LOGGER.error("Failed to set the Webhook data. Message: " + e.getMessage());
+			LOGGER.error("Failed to set the webhook data. Message: " + e.getMessage());
 			return Response.status(Status.CONFLICT).build();
 		}
 	}
@@ -306,7 +306,7 @@ public class ConfigRest {
 			ConfigPersistenceManager.setWebhookType(projectKey, webhookType, isWebhookTypeEnabled);
 			return Response.ok(Status.ACCEPTED).build();
 		} catch (Exception e) {
-			LOGGER.error("Failed to set the Webhook type: "+ webhookType + " Message: " + e.getMessage());
+			LOGGER.error("Failed to set the webhook type: "+ webhookType + " Message: " + e.getMessage());
 			return Response.status(Status.CONFLICT).build();
 		}
 	}
@@ -332,7 +332,7 @@ public class ConfigRest {
 			JiraIssueTextPersistenceManager.migrateArgumentTypesInLinks(projectKey);
 			return Response.ok(Status.ACCEPTED).build();
 		} catch (Exception e) {
-			LOGGER.error("Failed to clean the Sentence Database. Message: " + e.getMessage());
+			LOGGER.error("Failed to clean the sentence database. Message: " + e.getMessage());
 			return Response.status(Status.CONFLICT).build();
 		}
 	}
@@ -428,7 +428,7 @@ public class ConfigRest {
 			ConfigPersistenceManager.setIconParsing(projectKey, isActivated);
 			return Response.ok(Status.ACCEPTED).build();
 		} catch (Exception e) {
-			LOGGER.error("Failed to set icon parsing. Message: " + e.getMessage());
+			LOGGER.error("Failed to enable or disable icon parsing. Message: " + e.getMessage());
 			return Response.status(Status.CONFLICT).build();
 		}
 	}
@@ -451,7 +451,7 @@ public class ConfigRest {
 			ConfigPersistenceManager.setUseClassiferForIssueComments(projectKey, isActivated);
 			return Response.ok(Status.ACCEPTED).build();
 		} catch (Exception e) {
-			LOGGER.error("Failed to enable the user classifier for issue comments. Message: " + e.getMessage());
+			LOGGER.error("Failed to enable or disable the classifier for JIRA issue text. Message: " + e.getMessage());
 			return Response.status(Status.CONFLICT).build();
 		}
 	}

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/rest/ConfigRest.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/rest/ConfigRest.java
@@ -63,7 +63,7 @@ public class ConfigRest {
 			setDefaultKnowledgeTypesEnabled(projectKey, isActivated);
 			return Response.ok(Status.ACCEPTED).build();
 		} catch (Exception e) {
-			LOGGER.error(e.getMessage());
+			LOGGER.error("Failed to activate the plug-in. Message: " + e.getMessage());
 			return Response.status(Status.CONFLICT).build();
 		}
 	}
@@ -104,7 +104,7 @@ public class ConfigRest {
 			manageDefaultIssueTypes(projectKey, isIssueStrategy);
 			return Response.ok(Status.ACCEPTED).build();
 		} catch (Exception e) {
-			LOGGER.error(e.getMessage());
+			LOGGER.error("Failed to apply the issue strategy. Message: " + e.getMessage());
 			return Response.status(Status.CONFLICT).build();
 		}
 	}
@@ -140,7 +140,7 @@ public class ConfigRest {
 					Boolean.valueOf(isKnowledgeExtractedFromGit));
 			return Response.ok(Status.ACCEPTED).build();
 		} catch (Exception e) {
-			LOGGER.error(e.getMessage());
+			LOGGER.error("Failed to active the knowledge extraction from git. Message: " + e.getMessage());
 			return Response.status(Status.CONFLICT).build();
 		}
 	}
@@ -179,7 +179,7 @@ public class ConfigRest {
 					Boolean.valueOf(isKnowledgeExtractedFromIssues));
 			return Response.ok(Status.ACCEPTED).build();
 		} catch (Exception e) {
-			LOGGER.error(e.getMessage());
+			LOGGER.error("Failed to activate the extraction of knowledge from issues. Message: " +  e.getMessage());
 			return Response.status(Status.CONFLICT).build();
 		}
 	}
@@ -223,7 +223,7 @@ public class ConfigRest {
 			}
 			return Response.ok(Status.ACCEPTED).build();
 		} catch (Exception e) {
-			LOGGER.error(e.getMessage());
+			LOGGER.error("Failed to enable the knowledge type: " + knowledgeType + " Message: " + e.getMessage());
 			return Response.status(Status.CONFLICT).build();
 		}
 	}
@@ -263,7 +263,7 @@ public class ConfigRest {
 			ConfigPersistenceManager.setWebhookEnabled(projectKey, isActivated);
 			return Response.ok(Status.ACCEPTED).build();
 		} catch (Exception e) {
-			LOGGER.error(e.getMessage());
+			LOGGER.error("Failed to enable the Webhook. Message: " + e.getMessage());
 			return Response.status(Status.CONFLICT).build();
 		}
 	}
@@ -285,7 +285,7 @@ public class ConfigRest {
 			ConfigPersistenceManager.setWebhookSecret(projectKey, webhookSecret);
 			return Response.ok(Status.ACCEPTED).build();
 		} catch (Exception e) {
-			LOGGER.error(e.getMessage());
+			LOGGER.error("Failed to set the Webhook data. Message: " + e.getMessage());
 			return Response.status(Status.CONFLICT).build();
 		}
 	}
@@ -306,7 +306,7 @@ public class ConfigRest {
 			ConfigPersistenceManager.setWebhookType(projectKey, webhookType, isWebhookTypeEnabled);
 			return Response.ok(Status.ACCEPTED).build();
 		} catch (Exception e) {
-			LOGGER.error(e.getMessage());
+			LOGGER.error("Failed to set the Webhook type: "+ webhookType + " Message: " + e.getMessage());
 			return Response.status(Status.CONFLICT).build();
 		}
 	}
@@ -332,7 +332,7 @@ public class ConfigRest {
 			JiraIssueTextPersistenceManager.migrateArgumentTypesInLinks(projectKey);
 			return Response.ok(Status.ACCEPTED).build();
 		} catch (Exception e) {
-			LOGGER.error(e.getMessage());
+			LOGGER.error("Failed to clean the Sentence Database. Message: " + e.getMessage());
 			return Response.status(Status.CONFLICT).build();
 		}
 	}
@@ -365,7 +365,7 @@ public class ConfigRest {
 
 			return Response.ok(Status.ACCEPTED).entity(ImmutableMap.of("isSucceeded", true)).build();
 		} catch (Exception e) {
-			LOGGER.error(e.getMessage());
+			LOGGER.error("Failed to classify the whole project. Message: " + e.getMessage());
 			return Response.status(Status.CONFLICT).entity(ImmutableMap.of("isSucceeded", false)).build();
 		}
 	}
@@ -428,7 +428,7 @@ public class ConfigRest {
 			ConfigPersistenceManager.setIconParsing(projectKey, isActivated);
 			return Response.ok(Status.ACCEPTED).build();
 		} catch (Exception e) {
-			LOGGER.error(e.getMessage());
+			LOGGER.error("Failed to set icon parsing. Message: " + e.getMessage());
 			return Response.status(Status.CONFLICT).build();
 		}
 	}
@@ -451,7 +451,7 @@ public class ConfigRest {
 			ConfigPersistenceManager.setUseClassiferForIssueComments(projectKey, isActivated);
 			return Response.ok(Status.ACCEPTED).build();
 		} catch (Exception e) {
-			LOGGER.error(e.getMessage());
+			LOGGER.error("Failed to enable the user classifier for issue comments. Message: " + e.getMessage());
 			return Response.status(Status.CONFLICT).build();
 		}
 	}

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/rest/ViewRest.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/rest/ViewRest.java
@@ -89,7 +89,7 @@ public class ViewRest {
 		try {
 			depth = Integer.parseInt(depthOfTree);
 		} catch (NumberFormatException e) {
-			LOGGER.error("Depth of tree could not be parsed, the default value of 4 is used.");
+			LOGGER.error("Depth of tree could not be parsed, the default value of 4 is used. Message: " + e.getMessage());
 			return Response.status(Status.BAD_REQUEST)
 					.entity(ImmutableMap.of("error", "Treant cannot be shown since depth of Tree is NaN")).build();
 		}

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/webhook/WebhookConnector.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/webhook/WebhookConnector.java
@@ -123,7 +123,6 @@ public class WebhookConnector {
 			LOGGER.error("Could not send webhook data. The HTTP response code is: " + httpResponse);
 		} catch (IOException e) {
 			LOGGER.error("Could not send webhook data because of " + e.getMessage());
-			e.printStackTrace();
 		}
 		return false;
 	}

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/webhook/WebhookContentProvider.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/webhook/WebhookContentProvider.java
@@ -13,10 +13,10 @@ import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.methods.PostMethod;
 import org.apache.commons.httpclient.methods.StringRequestEntity;
 import org.codehaus.jackson.map.ObjectMapper;
-
-import de.uhd.ifi.se.decision.management.jira.view.treant.Treant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import de.uhd.ifi.se.decision.management.jira.view.treant.Treant;
 
 /**
  * Creates the content submitted via the webhook. The content consists of a key
@@ -51,7 +51,7 @@ public class WebhookContentProvider {
 			StringRequestEntity requestEntity = new StringRequestEntity(webhookData, "application/json", "UTF-8");
 			postMethod.setRequestEntity(requestEntity);
 		} catch (UnsupportedEncodingException e) {
-			LOGGER.error("Create post method failed. Message: " + e.getMessage());
+			LOGGER.error("Creating the post method failed. Message: " + e.getMessage());
 		}
 		Header header = new Header();
 		header.setName("X-Hub-Signature");
@@ -106,18 +106,18 @@ public class WebhookContentProvider {
 		try {
 			mac = Mac.getInstance(hashingAlgorithm);
 		} catch (NoSuchAlgorithmException e) {
-			LOGGER.error("Create a hashed payload failed. Message: " + e.getMessage());
+			LOGGER.error("Creating a hashed payload failed. Message: " + e.getMessage());
 		}
 		try {
 			mac.init(secretKeySpec);
 		} catch (InvalidKeyException e) {
-			LOGGER.error("Create a hashed payload failed. Message: " + e.getMessage());
+			LOGGER.error("Creating a hashed payload failed. Message: " + e.getMessage());
 		}
 		String hexString = "";
 		try {
 			hexString = toHexString(mac.doFinal(data.getBytes("UTF-8")));
 		} catch (IllegalStateException | UnsupportedEncodingException e) {
-			LOGGER.error("Create a hashed payload failed. Message: " + e.getMessage());
+			LOGGER.error("Creating a hashed payload failed. Message: " + e.getMessage());
 		}
 		return hexString;
 	}

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/webhook/WebhookContentProvider.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/webhook/WebhookContentProvider.java
@@ -15,6 +15,8 @@ import org.apache.commons.httpclient.methods.StringRequestEntity;
 import org.codehaus.jackson.map.ObjectMapper;
 
 import de.uhd.ifi.se.decision.management.jira.view.treant.Treant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Creates the content submitted via the webhook. The content consists of a key
@@ -26,6 +28,8 @@ public class WebhookContentProvider {
 	private String rootElementKey;
 	private String secret;
 
+	protected static final Logger LOGGER = LoggerFactory.getLogger(WebhookContentProvider.class);
+
 	public WebhookContentProvider(String projectKey, String elementKey, String secret) {
 		this.projectKey = projectKey;
 		this.rootElementKey = elementKey;
@@ -34,7 +38,7 @@ public class WebhookContentProvider {
 
 	/**
 	 * Creates post method for a single tree of decision knowledge.
-	 * 
+	 *
 	 * @return post method ready to be posted
 	 */
 	public PostMethod createPostMethod() {
@@ -47,7 +51,7 @@ public class WebhookContentProvider {
 			StringRequestEntity requestEntity = new StringRequestEntity(webhookData, "application/json", "UTF-8");
 			postMethod.setRequestEntity(requestEntity);
 		} catch (UnsupportedEncodingException e) {
-			e.printStackTrace();
+			LOGGER.error("Create post method failed. Message: " + e.getMessage());
 		}
 		Header header = new Header();
 		header.setName("X-Hub-Signature");
@@ -79,7 +83,7 @@ public class WebhookContentProvider {
 		try {
 			treantAsJson = objectMapper.writeValueAsString(treant);
 		} catch (IOException e) {
-			e.printStackTrace();
+			LOGGER.error("Failed to create a treant json string for the webhook. Message: " + e.getMessage());
 		}
 		return treantAsJson;
 	}
@@ -102,18 +106,18 @@ public class WebhookContentProvider {
 		try {
 			mac = Mac.getInstance(hashingAlgorithm);
 		} catch (NoSuchAlgorithmException e) {
-			e.printStackTrace();
+			LOGGER.error("Create a hashed payload failed. Message: " + e.getMessage());
 		}
 		try {
 			mac.init(secretKeySpec);
 		} catch (InvalidKeyException e) {
-			e.printStackTrace();
+			LOGGER.error("Create a hashed payload failed. Message: " + e.getMessage());
 		}
 		String hexString = "";
 		try {
 			hexString = toHexString(mac.doFinal(data.getBytes("UTF-8")));
 		} catch (IllegalStateException | UnsupportedEncodingException e) {
-			e.printStackTrace();
+			LOGGER.error("Create a hashed payload failed. Message: " + e.getMessage());
 		}
 		return hexString;
 	}

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/webhook/WebhookContentProvider.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/webhook/WebhookContentProvider.java
@@ -102,21 +102,12 @@ public class WebhookContentProvider {
 	public static String createHashedPayload(String data, String key) {
 		final String hashingAlgorithm = "HMACSHA256";
 		SecretKeySpec secretKeySpec = new SecretKeySpec(key.getBytes(), hashingAlgorithm);
-		Mac mac = null;
-		try {
-			mac = Mac.getInstance(hashingAlgorithm);
-		} catch (NoSuchAlgorithmException e) {
-			LOGGER.error("Creating a hashed payload failed. Message: " + e.getMessage());
-		}
-		try {
-			mac.init(secretKeySpec);
-		} catch (InvalidKeyException e) {
-			LOGGER.error("Creating a hashed payload failed. Message: " + e.getMessage());
-		}
 		String hexString = "";
 		try {
+			Mac mac = Mac.getInstance(hashingAlgorithm);
+			mac.init(secretKeySpec);
 			hexString = toHexString(mac.doFinal(data.getBytes("UTF-8")));
-		} catch (IllegalStateException | UnsupportedEncodingException e) {
+		} catch (NoSuchAlgorithmException | InvalidKeyException | UnsupportedEncodingException e) {
 			LOGGER.error("Creating a hashed payload failed. Message: " + e.getMessage());
 		}
 		return hexString;

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/webhook/WebhookEventListener.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/webhook/WebhookEventListener.java
@@ -34,7 +34,7 @@ public class WebhookEventListener implements InitializingBean, DisposableBean {
 	@Autowired
 	public WebhookEventListener(EventPublisher eventPublisher) {
 		this.eventPublisher = eventPublisher;
-		LOGGER.info("Webhook Eventlistener was added to JIRA");
+		LOGGER.info("Webhook event listener was added to JIRA.");
 	}
 
 	/**
@@ -45,7 +45,7 @@ public class WebhookEventListener implements InitializingBean, DisposableBean {
 	@Override
 	public void afterPropertiesSet() throws Exception {
 		eventPublisher.register(this);
-		LOGGER.info("Webhook Eventlistener was added to JIRA");
+		LOGGER.info("Webhook event listener was added to JIRA.");
 	}
 
 	/**
@@ -56,7 +56,7 @@ public class WebhookEventListener implements InitializingBean, DisposableBean {
 	@Override
 	public void destroy() throws Exception {
 		eventPublisher.unregister(this);
-		LOGGER.info("Webhook Eventlistener was removed from JIRA");
+		LOGGER.info("Webhook event listener was removed from JIRA.");
 	}
 
 	@EventListener

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/webhook/WebhookEventListener.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/webhook/WebhookEventListener.java
@@ -1,5 +1,7 @@
 package de.uhd.ifi.se.decision.management.jira.webhook;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,9 +29,12 @@ public class WebhookEventListener implements InitializingBean, DisposableBean {
 	@JiraImport
 	private final EventPublisher eventPublisher;
 
+	protected static final Logger LOGGER = LoggerFactory.getLogger(WebhookEventListener.class);
+
 	@Autowired
 	public WebhookEventListener(EventPublisher eventPublisher) {
 		this.eventPublisher = eventPublisher;
+		LOGGER.info("Webhook Eventlistener was added to JIRA");
 	}
 
 	/**
@@ -40,6 +45,7 @@ public class WebhookEventListener implements InitializingBean, DisposableBean {
 	@Override
 	public void afterPropertiesSet() throws Exception {
 		eventPublisher.register(this);
+		LOGGER.info("Webhook Eventlistener was added to JIRA");
 	}
 
 	/**
@@ -50,6 +56,7 @@ public class WebhookEventListener implements InitializingBean, DisposableBean {
 	@Override
 	public void destroy() throws Exception {
 		eventPublisher.unregister(this);
+		LOGGER.info("Webhook Eventlistener was removed from JIRA");
 	}
 
 	@EventListener

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/extraction/gitclient/TestSetUpGit.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/extraction/gitclient/TestSetUpGit.java
@@ -14,6 +14,8 @@ import org.eclipse.jgit.util.FS;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import de.uhd.ifi.se.decision.management.jira.TestSetUpWithIssues;
 import de.uhd.ifi.se.decision.management.jira.extraction.GitClient;
@@ -21,6 +23,7 @@ import de.uhd.ifi.se.decision.management.jira.extraction.impl.GitClientImpl;
 
 public class TestSetUpGit extends TestSetUpWithIssues {
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(TestSetUpGit.class);
 	protected static GitClient gitClient;
 
 	@BeforeClass
@@ -29,7 +32,8 @@ public class TestSetUpGit extends TestSetUpWithIssues {
 		String uri = getExampleUri();
 		gitClient = new GitClientImpl(uri, directory);
 		makeExampleCommit("readMe.txt", "TODO Write ReadMe", "Init Commit");
-		makeExampleCommit("readMe.txt", "Self-explanatory, ReadMe not necessary.", "TEST-12: Explain how the great software works");
+		makeExampleCommit("readMe.txt", "Self-explanatory, ReadMe not necessary.",
+				"TEST-12: Explain how the great software works");
 		makeExampleCommit("GodClass.java", "public class GodClass {}", "TEST-12: Develop great software");
 	}
 
@@ -77,7 +81,7 @@ public class TestSetUpGit extends TestSetUpWithIssues {
 			git.commit().setMessage(commitMessage).setAuthor("gitTest", "gitTest@test.de").call();
 			git.push().setRemote("origin").call();
 		} catch (GitAPIException | FileNotFoundException | UnsupportedEncodingException e) {
-			e.printStackTrace();
+			LOGGER.error("Mock commit failed. Message: " + e.getMessage());
 		}
 	}
 

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/persistence/jiraissuepersistencemanager/TestDeleteDecisionKnowledgeElement.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/persistence/jiraissuepersistencemanager/TestDeleteDecisionKnowledgeElement.java
@@ -5,8 +5,8 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+import com.atlassian.jira.component.ComponentAccessor;
 import com.atlassian.jira.user.ApplicationUser;
-import com.atlassian.jira.user.MockApplicationUser;
 
 import de.uhd.ifi.se.decision.management.jira.model.DecisionKnowledgeElement;
 import de.uhd.ifi.se.decision.management.jira.model.KnowledgeType;
@@ -31,7 +31,6 @@ public class TestDeleteDecisionKnowledgeElement extends TestJiraIssuePersistence
 		element.setId(1);
 		element.setProject("TEST");
 		element.setType(KnowledgeType.SOLUTION);
-		ApplicationUser user = new MockApplicationUser("NoFails");
 		assertTrue(issueStrategy.deleteDecisionKnowledgeElement(element, user));
 	}
 
@@ -41,27 +40,7 @@ public class TestDeleteDecisionKnowledgeElement extends TestJiraIssuePersistence
 		element.setId(1);
 		element.setProject("TEST");
 		element.setType(KnowledgeType.SOLUTION);
-		ApplicationUser user = new MockApplicationUser("WithFails");
-		assertFalse(issueStrategy.deleteDecisionKnowledgeElement(element, user));
-	}
-
-	@Test
-	public void testElementExistentUserNotAuthorizedResFails() {
-		DecisionKnowledgeElement element = new DecisionKnowledgeElementImpl();
-		element.setId(1);
-		element.setProject("TEST");
-		element.setType(KnowledgeType.SOLUTION);
-		ApplicationUser user = new MockApplicationUser("WithResFails");
-		assertFalse(issueStrategy.deleteDecisionKnowledgeElement(element, user));
-	}
-
-	@Test
-	public void testElementExistentUserNotAuthorizedResultErrors() {
-		DecisionKnowledgeElement element = new DecisionKnowledgeElementImpl();
-		element.setId(1);
-		element.setProject("TEST");
-		element.setType(KnowledgeType.SOLUTION);
-		ApplicationUser user = new MockApplicationUser("ValidNoResErrors");
+		ApplicationUser user = ComponentAccessor.getUserManager().getUserByName("WithFails");
 		assertFalse(issueStrategy.deleteDecisionKnowledgeElement(element, user));
 	}
 }

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/persistence/jiraissuepersistencemanager/TestInsertDecisionKnowledgeElement.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/persistence/jiraissuepersistencemanager/TestInsertDecisionKnowledgeElement.java
@@ -5,8 +5,8 @@ import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
 
+import com.atlassian.jira.component.ComponentAccessor;
 import com.atlassian.jira.user.ApplicationUser;
-import com.atlassian.jira.user.MockApplicationUser;
 
 import de.uhd.ifi.se.decision.management.jira.model.DecisionKnowledgeElement;
 import de.uhd.ifi.se.decision.management.jira.model.KnowledgeType;
@@ -28,7 +28,6 @@ public class TestInsertDecisionKnowledgeElement extends TestJiraIssuePersistence
 	@Test(expected = NullPointerException.class)
 	public void testElementEmptyUserExistent() {
 		DecisionKnowledgeElement element = new DecisionKnowledgeElementImpl();
-		ApplicationUser user = new MockApplicationUser("NoFails");
 		assertNotNull(issueStrategy.insertDecisionKnowledgeElement(element, user));
 	}
 
@@ -37,7 +36,6 @@ public class TestInsertDecisionKnowledgeElement extends TestJiraIssuePersistence
 		DecisionKnowledgeElement element = new DecisionKnowledgeElementImpl();
 		element.setProject("TEST");
 		element.setType(KnowledgeType.SOLUTION);
-		ApplicationUser user = new MockApplicationUser("NoFails");
 		assertNotNull(issueStrategy.insertDecisionKnowledgeElement(element, user));
 	}
 
@@ -46,7 +44,7 @@ public class TestInsertDecisionKnowledgeElement extends TestJiraIssuePersistence
 		DecisionKnowledgeElementImpl element = new DecisionKnowledgeElementImpl();
 		element.setProject("TEST");
 		element.setType(KnowledgeType.SOLUTION);
-		ApplicationUser user = new MockApplicationUser("WithFails");
+		ApplicationUser user = ComponentAccessor.getUserManager().getUserByName("WithFails");
 		assertNull(issueStrategy.insertDecisionKnowledgeElement(element, user));
 	}
 }

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/persistence/jiraissuepersistencemanager/TestUpdateDecisionKnowledgeElement.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/persistence/jiraissuepersistencemanager/TestUpdateDecisionKnowledgeElement.java
@@ -5,8 +5,8 @@ import static org.junit.Assert.assertNotNull;
 
 import org.junit.Test;
 
+import com.atlassian.jira.component.ComponentAccessor;
 import com.atlassian.jira.user.ApplicationUser;
-import com.atlassian.jira.user.MockApplicationUser;
 
 import de.uhd.ifi.se.decision.management.jira.model.DecisionKnowledgeElement;
 import de.uhd.ifi.se.decision.management.jira.model.KnowledgeType;
@@ -27,7 +27,6 @@ public class TestUpdateDecisionKnowledgeElement extends TestJiraIssuePersistence
 
 	public void testElementNonExistentUserExistent() {
 		DecisionKnowledgeElement element = new DecisionKnowledgeElementImpl();
-		ApplicationUser user = new MockApplicationUser("NoFails");
 		assertNotNull(issueStrategy.updateDecisionKnowledgeElement(element, user));
 	}
 
@@ -37,7 +36,6 @@ public class TestUpdateDecisionKnowledgeElement extends TestJiraIssuePersistence
 		element.setId(1);
 		element.setProject("TEST");
 		element.setType(KnowledgeType.SOLUTION);
-		ApplicationUser user = new MockApplicationUser("NoFails");
 		assertNotNull(issueStrategy.updateDecisionKnowledgeElement(element, user));
 	}
 
@@ -47,7 +45,7 @@ public class TestUpdateDecisionKnowledgeElement extends TestJiraIssuePersistence
 		element.setId(1);
 		element.setProject("TEST");
 		element.setType(KnowledgeType.SOLUTION);
-		ApplicationUser user = new MockApplicationUser("WithFails");
+		ApplicationUser user = ComponentAccessor.getUserManager().getUserByName("WithFails");
 		assertFalse(issueStrategy.updateDecisionKnowledgeElement(element, user));
 	}
 }

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/rest/knowledgerest/TestGetSummarizedCode.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/rest/knowledgerest/TestGetSummarizedCode.java
@@ -4,18 +4,29 @@ import static org.junit.Assert.assertEquals;
 
 import javax.ws.rs.core.Response.Status;
 
+import com.atlassian.activeobjects.test.TestActiveObjects;
+import de.uhd.ifi.se.decision.management.jira.TestComponentGetter;
+import de.uhd.ifi.se.decision.management.jira.mocks.MockTransactionTemplate;
+import de.uhd.ifi.se.decision.management.jira.mocks.MockUserManager;
+import net.java.ao.EntityManager;
+import net.java.ao.test.junit.ActiveObjectsJUnitRunner;
 import org.junit.Before;
 import org.junit.Test;
 
 import de.uhd.ifi.se.decision.management.jira.extraction.gitclient.TestSetUpGit;
 import de.uhd.ifi.se.decision.management.jira.rest.KnowledgeRest;
+import org.junit.runner.RunWith;
 
+@RunWith(ActiveObjectsJUnitRunner.class)
 public class TestGetSummarizedCode extends TestSetUpGit {
 
+	private EntityManager entityManager;
 	private KnowledgeRest knowledgeRest;
 
 	@Before
 	public void setUp() {
+		TestComponentGetter.init(new TestActiveObjects(entityManager), new MockTransactionTemplate()
+				,new MockUserManager());
 		super.setUp();
 		knowledgeRest = new KnowledgeRest();
 	}

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/rest/knowledgerest/TestGetSummarizedCode.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/rest/knowledgerest/TestGetSummarizedCode.java
@@ -4,31 +4,20 @@ import static org.junit.Assert.assertEquals;
 
 import javax.ws.rs.core.Response.Status;
 
-import com.atlassian.activeobjects.test.TestActiveObjects;
-import de.uhd.ifi.se.decision.management.jira.TestComponentGetter;
-import de.uhd.ifi.se.decision.management.jira.mocks.MockTransactionTemplate;
-import de.uhd.ifi.se.decision.management.jira.mocks.MockUserManager;
-import net.java.ao.EntityManager;
-import net.java.ao.test.junit.ActiveObjectsJUnitRunner;
 import org.junit.Before;
 import org.junit.Test;
 
 import de.uhd.ifi.se.decision.management.jira.extraction.gitclient.TestSetUpGit;
 import de.uhd.ifi.se.decision.management.jira.rest.KnowledgeRest;
-import org.junit.runner.RunWith;
 
-@RunWith(ActiveObjectsJUnitRunner.class)
 public class TestGetSummarizedCode extends TestSetUpGit {
 
-	private EntityManager entityManager;
 	private KnowledgeRest knowledgeRest;
 
 	@Before
 	public void setUp() {
-		TestComponentGetter.init(new TestActiveObjects(entityManager), new MockTransactionTemplate()
-				,new MockUserManager());
-		super.setUp();
 		knowledgeRest = new KnowledgeRest();
+		super.setUp();
 	}
 
 	@Test


### PR DESCRIPTION
- Change version of slf4j from 1.6.6 to 1.7.25  …
- Change Sys.error and error messages to Logger outputs  …
- Change sys.error and info to logger.error and Info in Classi
- Change sys.error to Logger errors in GitClientImpl
- Add Logger as public variable and add logger outputs to t…  …
- Remove unused TODO
- Add Logger as public object to the decisisonknowledgeclas…  …
- Exchange e.stacktrace to logger.error
- Extend logger errors of GraphFiltering
- Change e.staktrace to logger.error in JiraSearchServiceHe…  …
- Add Logger to LinkImpl and extend staktrace
- Add Logger to PartOfJiraIsseuTextImpl and log error in co…  …
-Extend catch error message with the error message
- Extend JiraIssuePersistenceManager with logger outputs
- Extend catch log outputs in JiraIssueTextPersistenceManager
- Add log support for CommentMetricCalculator
- Extend the logger outputs with descriptions
- Extend the error log with the message in ViewRest
- Remove e.printStackTrace in WebhookConnector
- Add Logger to WebhookContentProvider and add loggs
- Add Logger to WebhookEventListener and log info to eventadd