### PR TITLE
ConDec-507: Build a super class for the EventListener

### DIFF
--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/eventlistener/ConDecEventListener.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/eventlistener/ConDecEventListener.java
@@ -1,0 +1,80 @@
+package de.uhd.ifi.se.decision.management.jira.eventlistener;
+
+import aQute.bnd.annotation.component.Component;
+import com.atlassian.event.api.EventListener;
+import com.atlassian.event.api.EventPublisher;
+import com.atlassian.jira.event.issue.IssueEvent;
+import com.atlassian.jira.event.issue.link.IssueLinkCreatedEvent;
+import com.atlassian.jira.event.issue.link.IssueLinkDeletedEvent;
+import com.atlassian.plugin.spring.scanner.annotation.imports.JiraImport;
+import de.uhd.ifi.se.decision.management.jira.model.DecisionKnowledgeElement;
+import de.uhd.ifi.se.decision.management.jira.model.impl.DecisionKnowledgeElementImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Component
+public class ConDecEventListener implements InitializingBean, DisposableBean {
+
+	@JiraImport
+	private final EventPublisher eventPublisher;
+	private WebhookEventListener webhookEventListener;
+	private DecXtractEventListener decXtractEventListener;
+
+	protected static final Logger LOGGER = LoggerFactory.getLogger(ConDecEventListener.class);
+
+	@Autowired
+	public ConDecEventListener(EventPublisher eventPublisher){
+		this.eventPublisher = eventPublisher;
+		LOGGER.info("ConDec event listener was added to JIRA");
+		webhookEventListener = new WebhookEventListener();
+		decXtractEventListener = new DecXtractEventListener();
+	}
+
+	/**
+	 * Called when the plugin has been enabled.
+	 *
+	 * @throws Exception
+	 */
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		eventPublisher.register(this);
+		LOGGER.info("ConDec event listener was added to JIRA.");
+	}
+
+	/**
+	 * Called when the plugin is being disabled or removed.
+	 *
+	 * @throws Exception
+	 */
+	@Override
+	public void destroy() throws Exception {
+		eventPublisher.unregister(this);
+		LOGGER.info("ConDec event listener was removed from JIRA.");
+	}
+
+	@EventListener
+	public void onIssueEvent(IssueEvent issueEvent){
+		if (issueEvent == null) {
+			return;
+		}
+		webhookEventListener.onIssueEvent(issueEvent);
+		decXtractEventListener.onIssueEvent(issueEvent);
+	}
+
+	@EventListener
+	public void onLinkCreatedIssueEvent(IssueLinkCreatedEvent linkCreatedEvent){
+		DecisionKnowledgeElement element = new DecisionKnowledgeElementImpl(linkCreatedEvent.getIssueLink().getSourceObject());
+		webhookEventListener.onLinkEvent(element);
+		LOGGER.info("ConDec event listener on link create issue event triggered");
+	}
+
+	@EventListener
+	public void onLinkDeletedIssueEvent(IssueLinkDeletedEvent linkDeletedEvent) {
+		DecisionKnowledgeElement element = new DecisionKnowledgeElementImpl(linkDeletedEvent.getIssueLink().getSourceObject());
+		webhookEventListener.onLinkEvent(element);
+		LOGGER.info("ConDec event listener on link deleted issue event triggered");
+	}
+}

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/eventlistener/ConDecEventListener.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/eventlistener/ConDecEventListener.java
@@ -22,6 +22,7 @@ public class ConDecEventListener implements InitializingBean, DisposableBean {
 	private final EventPublisher eventPublisher;
 	private WebhookEventListener webhookEventListener;
 	private DecXtractEventListener decXtractEventListener;
+	private SummarizationEventListener summarizationEventListener;
 
 	protected static final Logger LOGGER = LoggerFactory.getLogger(ConDecEventListener.class);
 
@@ -31,6 +32,7 @@ public class ConDecEventListener implements InitializingBean, DisposableBean {
 		LOGGER.info("ConDec event listener was added to JIRA");
 		webhookEventListener = new WebhookEventListener();
 		decXtractEventListener = new DecXtractEventListener();
+		summarizationEventListener = new SummarizationEventListener();
 	}
 
 	/**
@@ -62,6 +64,7 @@ public class ConDecEventListener implements InitializingBean, DisposableBean {
 		}
 		webhookEventListener.onIssueEvent(issueEvent);
 		decXtractEventListener.onIssueEvent(issueEvent);
+		summarizationEventListener.onIssueEvent(issueEvent);
 	}
 
 	@EventListener

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/eventlistener/DecXtractEventListener.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/eventlistener/DecXtractEventListener.java
@@ -1,9 +1,10 @@
-package de.uhd.ifi.se.decision.management.jira.extraction;
+package de.uhd.ifi.se.decision.management.jira.eventlistener;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import de.uhd.ifi.se.decision.management.jira.extraction.ClassificationManagerForJiraIssueComments;
 import org.ofbiz.core.entity.GenericEntityException;
 import org.ofbiz.core.entity.GenericValue;
 import org.slf4j.Logger;
@@ -34,10 +35,8 @@ import de.uhd.ifi.se.decision.management.jira.persistence.JiraIssueTextPersisten
  * description of a JIRA issue.
  */
 @Component
-public class DecXtractEventListener implements InitializingBean, DisposableBean {
+public class DecXtractEventListener{
 
-	@JiraImport
-	private final EventPublisher eventPublisher;
 	private String projectKey;
 	private IssueEvent issueEvent;
 	private static final Logger LOGGER = LoggerFactory.getLogger(DecXtractEventListener.class);
@@ -47,36 +46,7 @@ public class DecXtractEventListener implements InitializingBean, DisposableBean 
 	 */
 	public static boolean editCommentLock;
 
-	@Autowired
-	public DecXtractEventListener(EventPublisher eventPublisher) {
-		this.eventPublisher = eventPublisher;
-	}
-
-	/**
-	 * Called when the plugin has been enabled.
-	 * 
-	 * @throws Exception
-	 */
-	@Override
-	public void afterPropertiesSet() throws Exception {
-		eventPublisher.register(this);
-	}
-
-	/**
-	 * Called when the plugin is being disabled or removed.
-	 * 
-	 * @throws Exception
-	 */
-	@Override
-	public void destroy() throws Exception {
-		eventPublisher.unregister(this);
-	}
-
-	@EventListener
 	public void onIssueEvent(IssueEvent issueEvent) {
-		if (issueEvent == null) {
-			return;
-		}
 		this.issueEvent = issueEvent;
 		this.projectKey = issueEvent.getProject().getKey();
 

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/eventlistener/DecXtractEventListener.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/eventlistener/DecXtractEventListener.java
@@ -9,20 +9,14 @@ import org.ofbiz.core.entity.GenericEntityException;
 import org.ofbiz.core.entity.GenericValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.DisposableBean;
-import org.springframework.beans.factory.InitializingBean;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import com.atlassian.event.api.EventListener;
-import com.atlassian.event.api.EventPublisher;
 import com.atlassian.jira.component.ComponentAccessor;
 import com.atlassian.jira.event.issue.IssueEvent;
 import com.atlassian.jira.event.type.EventType;
 import com.atlassian.jira.issue.MutableIssue;
 import com.atlassian.jira.issue.comments.MutableComment;
 import com.atlassian.jira.util.collect.MapBuilder;
-import com.atlassian.plugin.spring.scanner.annotation.imports.JiraImport;
 
 import de.uhd.ifi.se.decision.management.jira.model.text.TextSplitter;
 import de.uhd.ifi.se.decision.management.jira.persistence.ConfigPersistenceManager;

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/eventlistener/DecXtractEventListener.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/eventlistener/DecXtractEventListener.java
@@ -28,7 +28,6 @@ import de.uhd.ifi.se.decision.management.jira.persistence.JiraIssueTextPersisten
  * in the knowledge graph when the user changes either a comment or the
  * description of a JIRA issue.
  */
-@Component
 public class DecXtractEventListener{
 
 	private String projectKey;

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/eventlistener/SummarizationEventListener.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/eventlistener/SummarizationEventListener.java
@@ -1,4 +1,4 @@
-package de.uhd.ifi.se.decision.management.jira.extraction;
+package de.uhd.ifi.se.decision.management.jira.eventlistener;
 
 import org.ofbiz.core.entity.GenericValue;
 import org.springframework.beans.factory.DisposableBean;
@@ -24,40 +24,11 @@ import de.uhd.ifi.se.decision.management.jira.persistence.ConfigPersistenceManag
  * Triggers the code summarization when JIRA issues are closed. Then, the
  * summary is written into a new comment of the JIRA issue.
  */
-@Component
-public class SummarizationEventListener implements InitializingBean, DisposableBean {
+public class SummarizationEventListener{
 
 	private final ChangeHistoryManager changeManager = ComponentAccessor.getChangeHistoryManager();
 
-	@JiraImport
-	private final EventPublisher eventPublisher;
 
-	@Autowired
-	public SummarizationEventListener(EventPublisher eventPublisher) {
-		this.eventPublisher = eventPublisher;
-	}
-
-	/**
-	 * Called when the plugin has been enabled.
-	 * 
-	 * @throws Exception
-	 */
-	@Override
-	public void afterPropertiesSet() throws Exception {
-		eventPublisher.register(this);
-	}
-
-	/**
-	 * Called when the plugin is being disabled or removed.
-	 * 
-	 * @throws Exception
-	 */
-	@Override
-	public void destroy() throws Exception {
-		eventPublisher.unregister(this);
-	}
-
-	@EventListener
 	public void onIssueEvent(IssueEvent issueEvent) {
 		String projectKey = issueEvent.getProject().getKey();
 		String jiraIssueKey = issueEvent.getIssue().getKey();

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/eventlistener/WebhookEventListener.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/eventlistener/WebhookEventListener.java
@@ -1,10 +1,10 @@
-package de.uhd.ifi.se.decision.management.jira.webhook;
+package de.uhd.ifi.se.decision.management.jira.eventlistener;
 
+import de.uhd.ifi.se.decision.management.jira.webhook.WebhookConnector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.atlassian.event.api.EventListener;
@@ -23,43 +23,11 @@ import de.uhd.ifi.se.decision.management.jira.persistence.ConfigPersistenceManag
  * Triggers the webhook when JIRA issues are created, updated, or deleted or
  * when links between JIRA issues are created or deleted
  */
-@Component
-public class WebhookEventListener implements InitializingBean, DisposableBean {
+public class WebhookEventListener{
 
-	@JiraImport
-	private final EventPublisher eventPublisher;
 
 	protected static final Logger LOGGER = LoggerFactory.getLogger(WebhookEventListener.class);
 
-	@Autowired
-	public WebhookEventListener(EventPublisher eventPublisher) {
-		this.eventPublisher = eventPublisher;
-		LOGGER.info("Webhook event listener was added to JIRA.");
-	}
-
-	/**
-	 * Called when the plugin has been enabled.
-	 * 
-	 * @throws Exception
-	 */
-	@Override
-	public void afterPropertiesSet() throws Exception {
-		eventPublisher.register(this);
-		LOGGER.info("Webhook event listener was added to JIRA.");
-	}
-
-	/**
-	 * Called when the plugin is being disabled or removed.
-	 * 
-	 * @throws Exception
-	 */
-	@Override
-	public void destroy() throws Exception {
-		eventPublisher.unregister(this);
-		LOGGER.info("Webhook event listener was removed from JIRA.");
-	}
-
-	@EventListener
 	public void onIssueEvent(IssueEvent issueEvent) {
 		String projectKey = issueEvent.getProject().getKey();
 		if (!ConfigPersistenceManager.isWebhookEnabled(projectKey)) {
@@ -77,27 +45,11 @@ public class WebhookEventListener implements InitializingBean, DisposableBean {
 		}
 	}
 
-	@EventListener
-	public void onLinkCreatedIssueEvent(IssueLinkCreatedEvent linkCreatedEvent) {
-		String projectKey = linkCreatedEvent.getIssueLink().getSourceObject().getProjectObject().getKey();
-		DecisionKnowledgeElement decisionKnowledgeElement = new DecisionKnowledgeElementImpl(
-				linkCreatedEvent.getIssueLink().getSourceObject());
-		if (!ConfigPersistenceManager.isWebhookEnabled(projectKey)) {
+	public void onLinkEvent(DecisionKnowledgeElement decisionKnowledgeElement){
+		if(!ConfigPersistenceManager.isWebhookEnabled(decisionKnowledgeElement.getProject().getProjectKey())){
 			return;
 		}
-		WebhookConnector connector = new WebhookConnector(projectKey);
-		connector.sendElementChanges(decisionKnowledgeElement);
-	}
-
-	@EventListener
-	public void onLinkDeletedIssueEvent(IssueLinkDeletedEvent linkDeletedEvent) {
-		String projectKey = linkDeletedEvent.getIssueLink().getSourceObject().getProjectObject().getKey();
-		DecisionKnowledgeElement decisionKnowledgeElement = new DecisionKnowledgeElementImpl(
-				linkDeletedEvent.getIssueLink().getSourceObject());
-		if (!ConfigPersistenceManager.isWebhookEnabled(projectKey)) {
-			return;
-		}
-		WebhookConnector connector = new WebhookConnector(projectKey);
+		WebhookConnector connector = new WebhookConnector(decisionKnowledgeElement.getProject().getProjectKey());
 		connector.sendElementChanges(decisionKnowledgeElement);
 	}
 }

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/eventlistener/WebhookEventListener.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/eventlistener/WebhookEventListener.java
@@ -3,17 +3,9 @@ package de.uhd.ifi.se.decision.management.jira.eventlistener;
 import de.uhd.ifi.se.decision.management.jira.webhook.WebhookConnector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.DisposableBean;
-import org.springframework.beans.factory.InitializingBean;
-import org.springframework.stereotype.Component;
 
-import com.atlassian.event.api.EventListener;
-import com.atlassian.event.api.EventPublisher;
 import com.atlassian.jira.event.issue.IssueEvent;
-import com.atlassian.jira.event.issue.link.IssueLinkCreatedEvent;
-import com.atlassian.jira.event.issue.link.IssueLinkDeletedEvent;
 import com.atlassian.jira.event.type.EventType;
-import com.atlassian.plugin.spring.scanner.annotation.imports.JiraImport;
 
 import de.uhd.ifi.se.decision.management.jira.model.DecisionKnowledgeElement;
 import de.uhd.ifi.se.decision.management.jira.model.impl.DecisionKnowledgeElementImpl;

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/persistence/JiraIssueTextPersistenceManager.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/persistence/JiraIssueTextPersistenceManager.java
@@ -18,7 +18,7 @@ import com.atlassian.jira.issue.link.IssueLinkManager;
 import com.atlassian.jira.user.ApplicationUser;
 
 import de.uhd.ifi.se.decision.management.jira.ComponentGetter;
-import de.uhd.ifi.se.decision.management.jira.extraction.DecXtractEventListener;
+import de.uhd.ifi.se.decision.management.jira.eventlistener.DecXtractEventListener;
 import de.uhd.ifi.se.decision.management.jira.model.DecisionKnowledgeElement;
 import de.uhd.ifi.se.decision.management.jira.model.DocumentationLocation;
 import de.uhd.ifi.se.decision.management.jira.model.KnowledgeType;

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/eventlistener/TestWebhookEventListener.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/eventlistener/TestWebhookEventListener.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertNotNull;
 
 import java.util.HashMap;
 
-import de.uhd.ifi.se.decision.management.jira.eventlistener.WebhookEventListener;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/eventlistener/TestWebhookEventListener.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/eventlistener/TestWebhookEventListener.java
@@ -1,9 +1,10 @@
-package de.uhd.ifi.se.decision.management.jira.webhook;
+package de.uhd.ifi.se.decision.management.jira.eventlistener;
 
 import static org.junit.Assert.assertNotNull;
 
 import java.util.HashMap;
 
+import de.uhd.ifi.se.decision.management.jira.eventlistener.WebhookEventListener;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -37,7 +38,7 @@ import net.java.ao.test.junit.ActiveObjectsJUnitRunner;
 public class TestWebhookEventListener extends TestSetUpWithIssues {
 
 	private EntityManager entityManager;
-	private WebhookEventListener listener;
+	private ConDecEventListener listener;
 	private ApplicationUser user;
 	private Issue issue;
 	private Comment jiraComment;
@@ -48,7 +49,7 @@ public class TestWebhookEventListener extends TestSetUpWithIssues {
 		TestComponentGetter.init(new TestActiveObjects(entityManager), new MockTransactionTemplate(),
 				new MockUserManager());
 		EventPublisher publisher = new MockEventPublisher();
-		listener = new WebhookEventListener(publisher);
+		listener = new ConDecEventListener(publisher);
 		issue = ComponentAccessor.getIssueManager().getIssueByCurrentKey("TEST-4");
 		user = ComponentAccessor.getUserManager().getUserByName("NoFails");
 		jiraComment = ComponentAccessor.getCommentManager().create(issue, user, "Test Comment", true);

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/eventlistener/decxtracteventlistener/TestEventCommentAdded.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/eventlistener/decxtracteventlistener/TestEventCommentAdded.java
@@ -1,4 +1,4 @@
-package de.uhd.ifi.se.decision.management.jira.extraction.decxtracteventlistener;
+package de.uhd.ifi.se.decision.management.jira.eventlistener.decxtracteventlistener;
 
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/eventlistener/decxtracteventlistener/TestEventCommentDeleted.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/eventlistener/decxtracteventlistener/TestEventCommentDeleted.java
@@ -1,4 +1,4 @@
-package de.uhd.ifi.se.decision.management.jira.extraction.decxtracteventlistener;
+package de.uhd.ifi.se.decision.management.jira.eventlistener.decxtracteventlistener;
 
 import static org.junit.Assert.assertTrue;
 

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/eventlistener/decxtracteventlistener/TestEventCommentEdited.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/eventlistener/decxtracteventlistener/TestEventCommentEdited.java
@@ -1,4 +1,4 @@
-package de.uhd.ifi.se.decision.management.jira.extraction.decxtracteventlistener;
+package de.uhd.ifi.se.decision.management.jira.eventlistener.decxtracteventlistener;
 
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/eventlistener/decxtracteventlistener/TestEventDescriptionEdited.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/eventlistener/decxtracteventlistener/TestEventDescriptionEdited.java
@@ -1,4 +1,4 @@
-package de.uhd.ifi.se.decision.management.jira.extraction.decxtracteventlistener;
+package de.uhd.ifi.se.decision.management.jira.eventlistener.decxtracteventlistener;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/eventlistener/decxtracteventlistener/TestEventIssueDeleted.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/eventlistener/decxtracteventlistener/TestEventIssueDeleted.java
@@ -1,4 +1,4 @@
-package de.uhd.ifi.se.decision.management.jira.extraction.decxtracteventlistener;
+package de.uhd.ifi.se.decision.management.jira.eventlistener.decxtracteventlistener;
 
 import static org.junit.Assert.assertTrue;
 

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/eventlistener/decxtracteventlistener/TestRegisterFunctions.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/eventlistener/decxtracteventlistener/TestRegisterFunctions.java
@@ -1,4 +1,4 @@
-package de.uhd.ifi.se.decision.management.jira.extraction.decxtracteventlistener;
+package de.uhd.ifi.se.decision.management.jira.eventlistener.decxtracteventlistener;
 
 import static org.junit.Assert.assertNotNull;
 

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/eventlistener/decxtracteventlistener/TestSetUpEventListener.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/eventlistener/decxtracteventlistener/TestSetUpEventListener.java
@@ -18,7 +18,6 @@ import com.atlassian.jira.user.ApplicationUser;
 
 import de.uhd.ifi.se.decision.management.jira.TestComponentGetter;
 import de.uhd.ifi.se.decision.management.jira.TestSetUpWithIssues;
-import de.uhd.ifi.se.decision.management.jira.eventlistener.DecXtractEventListener;
 import de.uhd.ifi.se.decision.management.jira.mocks.MockTransactionTemplate;
 import de.uhd.ifi.se.decision.management.jira.mocks.MockUserManager;
 import de.uhd.ifi.se.decision.management.jira.model.DecisionKnowledgeElement;

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/eventlistener/decxtracteventlistener/TestSetUpEventListener.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/eventlistener/decxtracteventlistener/TestSetUpEventListener.java
@@ -1,8 +1,9 @@
-package de.uhd.ifi.se.decision.management.jira.extraction.decxtracteventlistener;
+package de.uhd.ifi.se.decision.management.jira.eventlistener.decxtracteventlistener;
 
 import java.util.HashMap;
 import java.util.List;
 
+import de.uhd.ifi.se.decision.management.jira.eventlistener.ConDecEventListener;
 import org.junit.Before;
 
 import com.atlassian.activeobjects.test.TestActiveObjects;
@@ -17,7 +18,7 @@ import com.atlassian.jira.user.ApplicationUser;
 
 import de.uhd.ifi.se.decision.management.jira.TestComponentGetter;
 import de.uhd.ifi.se.decision.management.jira.TestSetUpWithIssues;
-import de.uhd.ifi.se.decision.management.jira.extraction.DecXtractEventListener;
+import de.uhd.ifi.se.decision.management.jira.eventlistener.DecXtractEventListener;
 import de.uhd.ifi.se.decision.management.jira.mocks.MockTransactionTemplate;
 import de.uhd.ifi.se.decision.management.jira.mocks.MockUserManager;
 import de.uhd.ifi.se.decision.management.jira.model.DecisionKnowledgeElement;
@@ -30,7 +31,7 @@ public class TestSetUpEventListener extends TestSetUpWithIssues {
 	protected MutableIssue jiraIssue;
 	private ApplicationUser user;
 
-	protected DecXtractEventListener listener;
+	protected ConDecEventListener listener;
 
 	@Before
 	public void setUp() {
@@ -38,7 +39,7 @@ public class TestSetUpEventListener extends TestSetUpWithIssues {
 		TestComponentGetter.init(new TestActiveObjects(entityManager), new MockTransactionTemplate(),
 				new MockUserManager());
 		EventPublisher publisher = new MockEventPublisher();
-		listener = new DecXtractEventListener(publisher);
+		listener = new ConDecEventListener(publisher);
 		jiraIssue = ComponentAccessor.getIssueManager().getIssueByCurrentKey("TEST-4");
 		user = ComponentAccessor.getUserManager().getUserByName("NoFails");
 	}


### PR DESCRIPTION
- Move all event listener (DecXtract, Webhook) in an own package eventlistener
- Add a super class that handles the event listener calls for DecXtract and the Webhook
-  Change test calls to the new ConDecEventListener class