### PR TITLE
ConDec-522: Update the version of the active objects library to the latest version 3.1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   - chmod a+x opt/atlassian-plugin-sdk/apache-maven-*/bin/*
   - export PATH=opt/atlassian-plugin-sdk/bin:opt/atlassian-plugin-sdk/apache-maven-*/bin:$PATH
 install: 
-  - atlas-package
+  - atlas-package -quiet
 notifications:
   email: false
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,4 @@ deploy:
     tags: true
     repo: cures-hub/cures-condec-jira
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  - bash <(curl -s https://codecov.io/bash) -f $TRAVIS_BUILD_DIR/target/site/jacoco-aggregate/jacoco.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,7 @@ before_install:
   - chmod a+x opt/atlassian-plugin-sdk/bin/*
   - chmod a+x opt/atlassian-plugin-sdk/apache-maven-*/bin/*
   - export PATH=opt/atlassian-plugin-sdk/bin:opt/atlassian-plugin-sdk/apache-maven-*/bin:$PATH
-install: true
-script:
+install: 
   - atlas-package
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,4 @@ deploy:
     tags: true
     repo: cures-hub/cures-condec-jira
 after_success:
-  - bash <(curl -s https://codecov.io/bash) -f $TRAVIS_BUILD_DIR/target/site/jacoco-aggregate/jacoco.xml
+  - bash <(curl -s https://codecov.io/bash) -f $TRAVIS_BUILD_DIR/target/site/jacoco/jacoco.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ before_install:
   - chmod a+x opt/atlassian-plugin-sdk/bin/*
   - chmod a+x opt/atlassian-plugin-sdk/apache-maven-*/bin/*
   - export PATH=opt/atlassian-plugin-sdk/bin:opt/atlassian-plugin-sdk/apache-maven-*/bin:$PATH
-install: 
+install: true
+script:
   - atlas-package -quiet
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - export PATH=opt/atlassian-plugin-sdk/bin:opt/atlassian-plugin-sdk/apache-maven-*/bin:$PATH
 install: true
 script:
-  - atlas-package -quiet
+  - atlas-package -quiet -P jacoco
 notifications:
   email: false
 deploy:

--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,7 @@
 			<version>20180813</version>
 		</dependency>
 	</dependencies>
+
 	<build>
 		<finalName>cures-condec-jira</finalName>
 		<plugins>
@@ -265,29 +266,43 @@
 					<verbose>false</verbose>
 				</configuration>
 			</plugin>
-			<!-- CodeCov Plug-in -->
-			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>${jacoco-version}</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-					<!-- attached to Maven test phase -->
-					<execution>
-						<id>report</id>
-						<phase>test</phase>
-						<goals>
-							<goal>report</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<!-- Creates coverage reports in target/site/jacoco/ -->
+		<profile>
+			<id>jacoco</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.jacoco</groupId>
+						<artifactId>jacoco-maven-plugin</artifactId>
+						<version>${jacoco-version}</version>
+						<executions>
+							<execution>
+								<goals>
+									<goal>prepare-agent</goal>
+								</goals>
+							</execution>
+							<!-- attached to Maven test phase -->
+							<execution>
+								<id>report</id>
+								<phase>test</phase>
+								<goals>
+									<goal>report</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
 	<properties>
 		<jira.version>8.2.3</jira.version>
 		<amps.version>8.0.2</amps.version>

--- a/pom.xml
+++ b/pom.xml
@@ -67,14 +67,14 @@
 		<dependency>
 			<groupId>com.atlassian.sal</groupId>
 			<artifactId>sal-api</artifactId>
-			<version>2.7.1</version>
+			<version>4.0.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<!-- Servlets -->
 		<dependency>
 			<groupId>com.atlassian.templaterenderer</groupId>
 			<artifactId>atlassian-template-renderer-api</artifactId>
-			<version>3.0.0</version>
+			<version>4.0.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -23,10 +23,6 @@
 			<name>Lars Tralle</name>
 		</developer>
 		<developer>
-			<id>ematios</id>
-			<name>Eleftherios Matios</name>
-		</developer>
-		<developer>
 			<id>Jcl15</id>
 			<name>Jochen Clormann</name>
 		</developer>
@@ -102,7 +98,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>5.1.3.RELEASE</version>
+			<version>5.1.8.RELEASE</version>
 			<scope>provided</scope>
 		</dependency>
 		<!-- REST -->
@@ -115,7 +111,7 @@
 		<dependency>
 			<groupId>javax.xml.bind</groupId>
 			<artifactId>jaxb-api</artifactId>
-			<version>2.1</version>
+			<version>2.3.1</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -123,11 +119,10 @@
 			<artifactId>gson</artifactId>
 			<version>2.2.2-atlassian-1</version>
 		</dependency>
-		<!-- https://mvnrepository.com/artifact/com.google.api-client/google-api-client -->
 		<dependency>
 			<groupId>com.google.api-client</groupId>
 			<artifactId>google-api-client</artifactId>
-			<version>1.14.1-beta</version>
+			<version>1.30.2</version>
 		</dependency>
 		<!-- Logger -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -129,12 +129,6 @@
 			<artifactId>google-api-client</artifactId>
 			<version>1.14.1-beta</version>
 		</dependency>
-		<!-- https://mvnrepository.com/artifact/com.google.guava/guava -->
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>12.0.1</version>
-		</dependency>
 		<!-- Logger -->
 		<dependency>
 			<groupId>org.slf4j</groupId>
@@ -302,7 +296,7 @@
 	<properties>
 		<jira.version>8.2.3</jira.version>
 		<amps.version>8.0.2</amps.version>
-		<ao.version>1.6.2</ao.version>
+		<ao.version>3.1.6</ao.version>
 		<jacoco-version>0.8.4</jacoco-version>
 		<atlassian.spring.scanner.version>2.1.10</atlassian.spring.scanner.version>
 		<!-- This key is also used in atlassian-plugin.xml -->

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,18 @@
 			<name>Tim Kuchenbuch</name>
 		</developer>
 		<developer>
+			<id>lw2011</id>
+			<name>Lukasz</name>
+		</developer>
+		<developer>
+			<id>ihamma</id>
+			<name>Ines Hamma</name>
+		</developer>
+		<developer>
+			<id>fagro501</id>
+			<name>Fabian Gronert</name>
+		</developer>
+		<developer>
 			<id>larstralle</id>
 			<name>Lars Tralle</name>
 		</developer>
@@ -27,20 +39,9 @@
 			<name>Jochen Clormann</name>
 		</developer>
 		<developer>
-			<id>vaman95</id>
-			<name>Vita Aman</name>
-		</developer>
-		<developer>
-			<id>fagro501</id>
-			<name>Fabian Gronert</name>
-		</developer>
-		<developer>
 			<id>EwaldRode</id>
 			<name>Ewald Rode</name>
-		</developer>
-		<developer>
-			<name>Ines Hamma</name>
-		</developer>
+		</developer>		
 	</developers>
 	<packaging>atlassian-plugin</packaging>
 	<dependencies>
@@ -119,18 +120,6 @@
 			<artifactId>gson</artifactId>
 			<version>2.2.2-atlassian-1</version>
 		</dependency>
-		<dependency>
-			<groupId>com.google.api-client</groupId>
-			<artifactId>google-api-client</artifactId>
-			<version>1.30.2</version>
-		</dependency>
-		<!-- Logger -->
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>1.7.25</version>
-			<scope>provided</scope>
-		</dependency>
 		<!-- Active Objects -->
 		<dependency>
 			<groupId>com.atlassian.activeobjects</groupId>
@@ -183,14 +172,14 @@
 			<version>1.8.0.10</version>
 			<scope>test</scope>
 		</dependency>
-		<!-- DecXtract -->
+		<!-- Classification of text as decision knowledge -->
 		<dependency>
 			<groupId>nz.ac.waikato.cms.weka</groupId>
 			<artifactId>weka-dev</artifactId>
 			<version>3.9.3</version>
 		</dependency>
 		<dependency>
-			<groupId>net.sf.meka</groupId><!-- https://mvnrepository.com/artifact/net.sf.meka/meka -->
+			<groupId>net.sf.meka</groupId>
 			<artifactId>meka</artifactId>
 			<version>1.9.2</version>
 		</dependency>
@@ -198,7 +187,7 @@
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>
 			<artifactId>org.eclipse.jgit</artifactId>
-			<version>5.0.1.201806211838-r</version>
+			<version>5.4.0.201906121030-r</version>
 		</dependency>
 		<!-- Code Summarization -->
 		<dependency>
@@ -210,7 +199,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.5.5</version>
+			<version>4.5.9</version>
 		</dependency>
 		<!-- JSON -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,13 @@
 			<artifactId>gson</artifactId>
 			<version>2.2.2-atlassian-1</version>
 		</dependency>
+		<!-- Logger -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.25</version>
+			<scope>provided</scope>
+		</dependency>
 		<!-- Active Objects -->
 		<dependency>
 			<groupId>com.atlassian.activeobjects</groupId>
@@ -142,12 +149,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.wink</groupId>
-			<artifactId>wink-client</artifactId>
-			<version>1.1.3-incubating</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-all</artifactId>
 			<version>1.10.19</version>
@@ -163,13 +164,6 @@
 			<groupId>com.atlassian.jira</groupId>
 			<artifactId>jira-func-tests</artifactId>
 			<version>${jira.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<!-- Database -->
-		<dependency>
-			<groupId>hsqldb</groupId>
-			<artifactId>hsqldb</artifactId>
-			<version>1.8.0.10</version>
 			<scope>test</scope>
 		</dependency>
 		<!-- Classification of text as decision knowledge -->
@@ -200,12 +194,6 @@
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
 			<version>4.5.9</version>
-		</dependency>
-		<!-- JSON -->
-		<dependency>
-			<groupId>org.json</groupId>
-			<artifactId>json</artifactId>
-			<version>20180813</version>
 		</dependency>
 	</dependencies>
 

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/mocks/MockComponentAccessor.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/mocks/MockComponentAccessor.java
@@ -10,6 +10,7 @@ import com.atlassian.jira.config.ConstantsManager;
 import com.atlassian.jira.config.IssueTypeManager;
 import com.atlassian.jira.config.util.JiraHome;
 import com.atlassian.jira.issue.IssueManager;
+import com.atlassian.jira.issue.changehistory.ChangeHistoryManager;
 import com.atlassian.jira.issue.comments.CommentManager;
 import com.atlassian.jira.issue.fields.config.FieldConfigScheme;
 import com.atlassian.jira.issue.fields.config.manager.IssueTypeSchemeManager;
@@ -55,7 +56,8 @@ public class MockComponentAccessor extends ComponentAccessor {
 				.addMock(CommentManager.class, new MockCommentManager())
 				.addMock(JiraHome.class, new MockJiraHomeForTesting())
 				.addMock(SearchService.class, new MockSearchService())
-				.addMock(TransactionTemplate.class, new MockTransactionTemplate());
+				.addMock(TransactionTemplate.class, new MockTransactionTemplate())
+				.addMock(ChangeHistoryManager.class, mock(ChangeHistoryManager.class));
 	}
 
 	public UserManager initUserManager() {

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/mocks/MockComponentAccessor.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/mocks/MockComponentAccessor.java
@@ -21,6 +21,7 @@ import com.atlassian.jira.mock.MockConstantsManager;
 import com.atlassian.jira.mock.MockProjectManager;
 import com.atlassian.jira.mock.component.MockComponentWorker;
 import com.atlassian.jira.project.ProjectManager;
+import com.atlassian.jira.security.PermissionManager;
 import com.atlassian.jira.security.roles.ProjectRoleManager;
 import com.atlassian.jira.user.ApplicationUser;
 import com.atlassian.jira.user.MockApplicationUser;
@@ -57,7 +58,8 @@ public class MockComponentAccessor extends ComponentAccessor {
 				.addMock(JiraHome.class, new MockJiraHomeForTesting())
 				.addMock(SearchService.class, new MockSearchService())
 				.addMock(TransactionTemplate.class, new MockTransactionTemplate())
-				.addMock(ChangeHistoryManager.class, mock(ChangeHistoryManager.class));
+				.addMock(ChangeHistoryManager.class, mock(ChangeHistoryManager.class))
+				.addMock(PermissionManager.class, mock(PermissionManager.class));
 	}
 
 	public UserManager initUserManager() {

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/mocks/MockUserManager.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/mocks/MockUserManager.java
@@ -6,6 +6,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import com.atlassian.jira.user.ApplicationUser;
 import com.atlassian.jira.user.MockApplicationUser;
+import com.atlassian.sal.api.user.UserKey;
 import com.atlassian.sal.api.user.UserManager;
 import com.atlassian.sal.api.user.UserProfile;
 import com.atlassian.sal.api.user.UserResolutionException;
@@ -58,6 +59,60 @@ public class MockUserManager implements UserManager {
 
 	@Override
 	public Principal resolve(String arg0) throws UserResolutionException {
+		return null;
+	}
+
+	@Override
+	public UserProfile getRemoteUser() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public UserKey getRemoteUserKey() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public UserProfile getRemoteUser(HttpServletRequest request) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public UserKey getRemoteUserKey(HttpServletRequest request) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public UserProfile getUserProfile(UserKey userKey) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public boolean isUserInGroup(UserKey userKey, String group) {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public boolean isSystemAdmin(UserKey userKey) {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public boolean isAdmin(UserKey userKey) {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public Iterable<String> findGroupNamesByPrefix(String prefix, int startIndex, int maxResults) {
+		// TODO Auto-generated method stub
 		return null;
 	}
 }

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/rest/viewrest/TestGetVis.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/rest/viewrest/TestGetVis.java
@@ -19,6 +19,7 @@ import de.uhd.ifi.se.decision.management.jira.config.AuthenticationManager;
 import de.uhd.ifi.se.decision.management.jira.filtering.FilterSettings;
 import de.uhd.ifi.se.decision.management.jira.filtering.impl.FilterSettingsImpl;
 import de.uhd.ifi.se.decision.management.jira.rest.ViewRest;
+import net.java.ao.test.jdbc.NonTransactional;
 
 public class TestGetVis extends TestSetUpWithIssues {
 
@@ -43,6 +44,7 @@ public class TestGetVis extends TestSetUpWithIssues {
 	}
 
 	@Test
+	@NonTransactional
 	public void testRequestNullFilterDataSettingsElementNull() {
 		assertEquals(
 				Response.status(Response.Status.INTERNAL_SERVER_ERROR)
@@ -51,6 +53,7 @@ public class TestGetVis extends TestSetUpWithIssues {
 	}
 
 	@Test
+	@NonTransactional
 	public void testRequestNullFilerSettingsNullElementNotExisting() {
 		assertEquals(
 				Response.status(Response.Status.INTERNAL_SERVER_ERROR)
@@ -59,6 +62,7 @@ public class TestGetVis extends TestSetUpWithIssues {
 	}
 
 	@Test
+	@NonTransactional
 	public void testRequestNullFilterSettingsNullElementExisting() {
 		assertEquals(
 				Response.status(Response.Status.INTERNAL_SERVER_ERROR)
@@ -67,6 +71,7 @@ public class TestGetVis extends TestSetUpWithIssues {
 	}
 
 	@Test
+	@NonTransactional
 	public void testRequestNullFilterSettingsFilledElementFilled() {
 		assertEquals(Response.status(Response.Status.INTERNAL_SERVER_ERROR)
 				.entity(ImmutableMap.of("error", INVALID_REQUEST)).build().getEntity(),
@@ -74,6 +79,7 @@ public class TestGetVis extends TestSetUpWithIssues {
 	}
 
 	@Test
+	@NonTransactional
 	public void testRequestFilledFilterSettingsFilledElementFilled() {
 		assertNotNull(AuthenticationManager.getUser(request));
 		assertEquals(Response.Status.OK.getStatusCode(),

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/view/vis/TestVisGraphEdge.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/view/vis/TestVisGraphEdge.java
@@ -11,6 +11,7 @@ import de.uhd.ifi.se.decision.management.jira.model.DecisionKnowledgeElement;
 import de.uhd.ifi.se.decision.management.jira.model.Link;
 import de.uhd.ifi.se.decision.management.jira.model.impl.DecisionKnowledgeElementImpl;
 import de.uhd.ifi.se.decision.management.jira.model.impl.LinkImpl;
+import net.java.ao.test.jdbc.NonTransactional;
 
 public class TestVisGraphEdge extends TestSetUpWithIssues {
 
@@ -45,24 +46,28 @@ public class TestVisGraphEdge extends TestSetUpWithIssues {
 	}
 
 	@Test
+	@NonTransactional
 	public void testConstructor() {
 		edge = new VisEdge(link);
 		assertNotNull(edge);
 	}
 
 	@Test
+	@NonTransactional
 	public void testId() {
 		edge = new VisEdge(link);
 		assertEquals(String.valueOf(link.getId()), edge.getId());
 	}
 
 	@Test
+	@NonTransactional
 	public void testLabel() {
 		edge = new VisEdge(link);
 		assertEquals(link.getType(), edge.getLabel());
 	}
 
 	@Test
+	@NonTransactional
 	public void testFrom() {
 		edge = new VisEdge(link);
 		String expected = link.getSourceElement().getId() + "_"
@@ -71,6 +76,7 @@ public class TestVisGraphEdge extends TestSetUpWithIssues {
 	}
 
 	@Test
+	@NonTransactional
 	public void testTo() {
 		edge = new VisEdge(link);
 		String expected = link.getDestinationElement().getId() + "_"


### PR DESCRIPTION
This pull requests updates the version of the active objects library to the latest version 3.1.6 and removes unneccessary dependencies with old versions such as guava from the pom.xml.