### PR TITLE
ConDec-524: Add REST API method to create decision knowledge element in the comment of an existing JIRA issue using its key

### DIFF
--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/rest/knowledgerest/TestCreateDecisionKnowledgeElement.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/rest/knowledgerest/TestCreateDecisionKnowledgeElement.java
@@ -45,74 +45,80 @@ public class TestCreateDecisionKnowledgeElement extends TestSetUp {
 	}
 
 	@Test
-	public void testRequestNullElementNullParentIdZeroParentDocumentationLocationNull() {
+	public void testRequestNullElementNullParentIdZeroParentDocumentationLocationNullKeyNull() {
 		assertEquals(Response.status(Status.BAD_REQUEST).entity(ImmutableMap.of("error", BAD_REQUEST_ERROR)).build()
-				.getEntity(), knowledgeRest.createDecisionKnowledgeElement(null, null, 0, null).getEntity());
+				.getEntity(), knowledgeRest.createDecisionKnowledgeElement(null, null, 0, null, null).getEntity());
 	}
 
 	@Test
-	public void testRequestNullElementFilledParentIdZeroParentDocumentationLocationNull() {
+	public void testRequestNullElementFilledParentIdZeroParentDocumentationLocationNullKeyNull() {
 		assertEquals(
 				Response.status(Status.BAD_REQUEST).entity(ImmutableMap.of("error", BAD_REQUEST_ERROR)).build()
 						.getEntity(),
-				knowledgeRest.createDecisionKnowledgeElement(null, decisionKnowledgeElement, 0, null).getEntity());
+				knowledgeRest.createDecisionKnowledgeElement(null, decisionKnowledgeElement, 0, null, null).getEntity());
 	}
 
 	@Test
-	public void testRequestFilledElementNullParentIdZeroParentDocumentationLocationNull() {
+	public void testRequestFilledElementNullParentIdZeroParentDocumentationLocationNullKeyNull() {
 		assertEquals(Response.status(Status.BAD_REQUEST).entity(ImmutableMap.of("error", BAD_REQUEST_ERROR)).build()
-				.getEntity(), knowledgeRest.createDecisionKnowledgeElement(request, null, 0, null).getEntity());
+				.getEntity(), knowledgeRest.createDecisionKnowledgeElement(request, null, 0, null, null).getEntity());
 	}
 
 	@Test
-	public void testRequestFilledElementFilledParentIdZeroParentDocumentationLocationNull() {
+	public void testRequestFilledElementFilledParentIdZeroParentDocumentationLocationNullKeyNull() {
 
 		assertEquals(Status.OK.getStatusCode(),
-				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, null).getStatus());
+				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, null, null).getStatus());
 	}
 
 	@Test
-	public void testRequestFilledElementFilledAsProArgumentParentIdZeroParentDocumentationLocationNull() {
+	public void testRequestFilledElementFilledAsProArgumentParentIdZeroParentDocumentationLocationNullKeyNull() {
 		decisionKnowledgeElement.setType("Pro-argument");
 		assertEquals(Status.OK.getStatusCode(),
-				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, null).getStatus());
+				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, null, null).getStatus());
 	}
 
 	@Test
-	public void testRequestFilledElementFilledAsConArgumentParentIdZeroParentDocumentationLocationNull() {
+	public void testRequestFilledElementFilledAsConArgumentParentIdZeroParentDocumentationLocationNullKeyNull() {
 		decisionKnowledgeElement.setType("Con-argument");
 		assertEquals(Status.OK.getStatusCode(),
-				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, null).getStatus());
+				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, null, null).getStatus());
 	}
 
 	@Test
-	public void testRequestFilledElementFilledParentIdZeroParentDocumentationLocationJiraIssue() {
+	public void testRequestFilledElementFilledParentIdZeroParentDocumentationLocationJiraIssueKeyNull() {
 		assertEquals(Status.OK.getStatusCode(),
-				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, "i").getStatus());
+				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, "i", null).getStatus());
 	}
 
 	@Test
-	public void testRequestFilledElementFilledParentIdFilledParentDocumentationLocationJiraIssue() {
+	public void testRequestFilledElementFilledParentIdFilledParentDocumentationLocationJiraIssueKeyNull() {
 		assertEquals(Status.OK.getStatusCode(),
-				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 7, "i").getStatus());
+				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 7, "i", null).getStatus());
 	}
 
 	@Test
-	public void testRequestFilledElementFilledParentIdFilledParentDocumentationLocationEmpty() {
+	public void testRequestFilledElementFilledParentIdFilledParentDocumentationLocationEmptyKeyNull() {
 		assertEquals(Status.OK.getStatusCode(),
-				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 7, "").getStatus());
+				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 7, "", null).getStatus());
 	}
 
 	@Test
-	public void testRequestFilledElementFilledParentIdFilledParentDocumentationLocationNull() {
+	public void testRequestFilledElementFilledParentIdFilledParentDocumentationLocationNullKeyNull() {
 		assertEquals(Status.OK.getStatusCode(),
-				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 3, null).getStatus());
+				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 3, null, null).getStatus());
 	}
 
 	@Test
 	@NonTransactional
-	public void testRequestFilledElementFilledParentIdZeroParentDocumentationLocationJiraIssueComment() {
+	public void testRequestFilledElementFilledParentIdZeroParentDocumentationLocationJiraIssueCommentKeyEmpty() {
 		assertEquals(Status.OK.getStatusCode(),
-				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, "s").getStatus());
+				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, "s", "").getStatus());
+	}
+	
+	@Test
+	public void testRequestFilledElementFilledParentIdZeroParentDocumentationLocationNullKeyExisting() {
+		assertEquals(Status.OK.getStatusCode(),
+				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, null, "TEST-3").getStatus());
 	}
 }


### PR DESCRIPTION
[issue] How to enable an external user (e.g. in Slack) to add a comment to an existing Jira issue containing decision knowledge? [/issue]
[decision] Add parameter keyOfExistingElement to createDecisionKnowledgeElement REST method of KnowledgeRest class! [/decision]
[alternative] Create new REST method! [/alternative]
[con] It is not clear for the user which method to use. [/con]