### PR TITLE
ConDec-558: add release-note classes, enums and tests

### DIFF
--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/releasenotes/ReleaseNote.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/releasenotes/ReleaseNote.java
@@ -1,0 +1,83 @@
+package de.uhd.ifi.se.decision.management.jira.releasenotes;
+
+import de.uhd.ifi.se.decision.management.jira.model.DecisionKnowledgeProject;
+import de.uhd.ifi.se.decision.management.jira.releasenotes.impl.ReleaseNoteImpl;
+import org.codehaus.jackson.map.annotate.JsonDeserialize;
+
+/**
+ * Interface for release notes
+ */
+@JsonDeserialize(as = ReleaseNoteImpl.class)
+public interface ReleaseNote {
+
+	/**
+	 * Get the id of the release note.
+	 * @return id of the release note.
+	 */
+	long getId();
+
+	/**
+	 * Set the id of the release note.
+	 * @param id of the release note.
+	 */
+	void setId(long id);
+
+	/**
+	 * Get the title of the release note.
+	 *
+	 * @return title of the release note.
+	 */
+	String getTitle();
+
+	/**
+	 * Set the summary of the release note.
+	 *
+	 * @param title of the release note.
+	 */
+	void setTitle(String title);
+	/**
+	 * Get the project that the release note belongs to. The project
+	 * is a JIRA project that is extended with settings for this plug-in, for
+	 * example, whether the plug-in is activated for the project.
+	 *
+	 * @see DecisionKnowledgeProject
+	 */
+	DecisionKnowledgeProject getProject();
+
+	/**
+	 * Set the project that the release note belongs to. The project
+	 * is a JIRA project that is extended with settings for this plug-in, for
+	 * example, whether the plug-in is activated for the project.
+	 *
+	 * @param project decision knowledge project.
+	 * @see DecisionKnowledgeProject
+	 */
+	void setProject(DecisionKnowledgeProject project);
+
+	/**
+	 * Set the project that the release note belongs to via its key.
+	 * The project is a JIRA project that is extended with settings for this
+	 * plug-in, for example, whether the plug-in is activated for the project.
+	 *
+	 * @param projectKey key of JIRA project.
+	 * @see DecisionKnowledgeProject
+	 */
+	void setProject(String projectKey);
+
+	/**
+	 * Get the content of the release note.
+	 * The content is in HTML, txt or md.
+	 *
+	 * @return content of the release note.
+	 */
+	String getContent();
+
+	/**
+	 * Set the description of the release note. The content
+	 * is in HTML, txt or md.
+	 *
+	 * @param content of the release note.
+	 */
+	void setContent(String content);
+
+}

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/releasenotes/ReleaseNoteConfiguration.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/releasenotes/ReleaseNoteConfiguration.java
@@ -1,0 +1,133 @@
+package de.uhd.ifi.se.decision.management.jira.releasenotes;
+
+import de.uhd.ifi.se.decision.management.jira.releasenotes.impl.ReleaseNoteConfigurationImpl;
+import org.codehaus.jackson.map.annotate.JsonDeserialize;
+
+import java.util.EnumMap;
+import java.util.List;
+
+/**
+ * Interface for release notes
+ */
+@JsonDeserialize(as = ReleaseNoteConfigurationImpl.class)
+public interface ReleaseNoteConfiguration {
+
+
+	/**
+	 * Get the startDate of the release note.
+	 *
+	 * @return startDate of the release note.
+	 */
+	String getStartDate();
+
+
+	/**
+	 * Set the startDate of the release note.
+	 *
+	 * @param startDate of the release note.
+	 */
+	void setStartDate(String startDate);
+
+
+	/**
+	 * Get the end Date of the release note.
+	 *
+	 * @return timeRange of the release note.
+	 */
+	String getEndDate();
+
+
+	/**
+	 * Set the end date of the release note.
+	 *
+	 * @param endDate of the release note.
+	 */
+	void setEndDate(String endDate);
+
+	/**
+	 * Get the sprint id of the release note.
+	 *
+	 * @return timeRange of the release note.
+	 */
+	String getSprintId();
+
+	/**
+	 * Set the sprint id  of the release note.
+	 *
+	 * @param sprintId of the release note.
+	 */
+	void setSprintId(String sprintId);
+
+
+	/**
+	 * Get the targetGroup of the release note.
+	 *
+	 * @return targetGroup of the release note.
+	 */
+	TargetGroup getTargetGroup();
+
+	/**
+	 * Set the targetGroup of the release note.
+	 *
+	 * @param targetGroup of the release note.
+	 */
+
+	void setTargetGroup(TargetGroup targetGroup);
+
+	/**
+	 * Get the taskCriteriaPrioritisation of the release note.
+	 *
+	 * @return taskCriteriaPrioritisation of the release note.
+	 */
+	EnumMap<TaskCriteriaPrioritisation, Double> getTaskCriteriaPrioritisation();
+
+	/**
+	 * Set the taskCriteriaPrioritisation of the release note.
+	 *
+	 * @param taskCriteriaPrioritisation of the release note.
+	 */
+	void setTaskCriteriaPrioritisation(EnumMap<TaskCriteriaPrioritisation, Double> taskCriteriaPrioritisation);
+
+	/**
+	 * Get the list with mapped bug fix issues.
+	 *
+	 * @return List<Integer>
+	 */
+	List<Integer> getBugFixMapping();
+
+	/**
+	 * Set the list with mapped bug fix issues.
+	 *
+	 * @param bugFixMapping of the release note.
+	 */
+	void setBugFixMapping(List<Integer> bugFixMapping);
+
+	/**
+	 * Get the list with mapped bug fix issues.
+	 *
+	 * @return List<Integer>
+	 */
+	List<Integer> getFeatureMapping();
+
+	/**
+	 * Set the list with mapped bug fix issues.
+	 *
+	 * @param featureMapping of the release note.
+	 */
+	void setFeatureMapping(List<Integer> featureMapping);
+
+	/**
+	 * Get the list with mapped bug fix issues.
+	 *
+	 * @return List<Integer>
+	 */
+	List<Integer> getImprovementMapping();
+
+	/**
+	 * Set the list with mapped bug fix issues.
+	 *
+	 * @param improvementMapping of the release note.
+	 */
+	void setImprovementMapping(List<Integer> improvementMapping);
+
+}

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/releasenotes/ReleaseNoteIssueProposal.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/releasenotes/ReleaseNoteIssueProposal.java
@@ -1,0 +1,59 @@
+package de.uhd.ifi.se.decision.management.jira.releasenotes;
+
+import de.uhd.ifi.se.decision.management.jira.model.DecisionKnowledgeElement;
+import de.uhd.ifi.se.decision.management.jira.releasenotes.impl.ReleaseNoteIssueProposalImpl;
+import org.codehaus.jackson.map.annotate.JsonDeserialize;
+
+import java.util.EnumMap;
+
+/**
+ * Interface Release Note Issue Proposal
+ * It saves the decision knowledge element, the final rating and the task criteria prioritisation metrics.
+ */
+@JsonDeserialize(as = ReleaseNoteIssueProposalImpl.class)
+public interface ReleaseNoteIssueProposal {
+
+	/**
+	 * Get the DecisionKnowledgeElement.
+	 *
+	 * @return DecisionKnowledgeElement of the ReleaseNoteIssueProposal.
+	 */
+	DecisionKnowledgeElement getDecisionKnowledgeElement();
+
+	/**
+	 * Set the DecisionKnowledgeElement.
+	 *
+	 * @param decisionKnowledgeElement of the ReleaseNoteIssueProposal.
+	 */
+	void setDecisionKnowledgeElement(DecisionKnowledgeElement decisionKnowledgeElement);
+
+	/**
+	 * Get rating of the ReleaseNoteIssueProposal.
+	 *
+	 * @return ratings of ReleaseNoteIssueProposal.
+	 */
+	double getRating();
+
+	/**
+	 * Set rating of the ReleaseNoteIssueProposal.
+	 *
+	 * @param rating of ReleaseNoteIssueProposal.
+	 */
+	void setRating(double rating);
+
+	/**
+	 * Get criteria prioritisation of the ReleaseNoteIssueProposal.
+	 *
+	 * @return taskCriteriaPrioritisation of ReleaseNoteIssueProposal.
+	 */
+	EnumMap<TaskCriteriaPrioritisation, Integer> getTaskCriteriaPrioritisation();
+
+	/**
+	 * Set criteria prioritisation of ReleaseNoteIssueProposal.
+	 *
+	 * @param taskCriteriaPrioritisation of ReleaseNoteIssueProposal.
+	 */
+	void setTaskCriteriaPrioritisation(EnumMap<TaskCriteriaPrioritisation, Integer> taskCriteriaPrioritisation);
+
+
+}

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/releasenotes/TargetGroup.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/releasenotes/TargetGroup.java
@@ -1,0 +1,34 @@
+package de.uhd.ifi.se.decision.management.jira.releasenotes;
+
+import java.util.Locale;
+
+/**
+ * Type of Target Groups for Release Notes
+ */
+public enum TargetGroup {
+	DEVELOPER, STAKEHOLDER, TESTER, ENDUSER;
+
+
+	@Override
+	public String toString() {
+		return this.name().toLowerCase(Locale.ENGLISH);
+	}
+
+
+	public static TargetGroup getTargetGroup(String type) {
+		if (type == null) {
+			return TargetGroup.DEVELOPER;
+		}
+		switch (type.toLowerCase(Locale.ENGLISH)) {
+			case "stakeholder":
+				return TargetGroup.STAKEHOLDER;
+			case "tester":
+				return TargetGroup.TESTER;
+			case "enduser":
+				return TargetGroup.ENDUSER;
+			default:
+				return TargetGroup.DEVELOPER;
+		}
+	}
+
+}

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/releasenotes/TaskCriteriaPrioritisation.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/releasenotes/TaskCriteriaPrioritisation.java
@@ -1,0 +1,84 @@
+package de.uhd.ifi.se.decision.management.jira.releasenotes;
+
+import java.util.*;
+
+
+public enum TaskCriteriaPrioritisation {
+	COUNT_DECISION_KNOWLEDGE, PRIORITY, COUNT_COMMENTS, SIZE_SUMMARY, SIZE_DESCRIPTION, DAYS_COMPLETION, EXPERIENCE_RESOLVER, EXPERIENCE_REPORTER;
+
+
+	@Override
+	public String toString() {
+		return this.name().toLowerCase(Locale.ENGLISH);
+	}
+
+
+	public static TaskCriteriaPrioritisation getTaskCriteriaPrioritisation(String type) {
+		if (type == null) {
+			return TaskCriteriaPrioritisation.COUNT_DECISION_KNOWLEDGE;
+		}
+		switch (type.toLowerCase(Locale.ENGLISH)) {
+			case "count_decision_knowledge":
+				return TaskCriteriaPrioritisation.COUNT_DECISION_KNOWLEDGE;
+			case "priority":
+				return TaskCriteriaPrioritisation.PRIORITY;
+			case "count_comments":
+				return TaskCriteriaPrioritisation.COUNT_COMMENTS;
+			case "size_summary":
+				return TaskCriteriaPrioritisation.SIZE_SUMMARY;
+			case "size_description":
+				return TaskCriteriaPrioritisation.SIZE_DESCRIPTION;
+			case "days_completion":
+				return TaskCriteriaPrioritisation.DAYS_COMPLETION;
+			case "experience_resolver":
+				return TaskCriteriaPrioritisation.EXPERIENCE_RESOLVER;
+			case "experience_reporter":
+				return TaskCriteriaPrioritisation.EXPERIENCE_REPORTER;
+			default:
+				return TaskCriteriaPrioritisation.COUNT_DECISION_KNOWLEDGE;
+		}
+	}
+
+	/**
+	 * @return hashMap of criterias with integer default 0.
+	 */
+	public static EnumMap<TaskCriteriaPrioritisation, Integer> toIntegerEnumMap() {
+		EnumMap<TaskCriteriaPrioritisation, Integer> criteriaTypes = new EnumMap<>(TaskCriteriaPrioritisation.class);
+		for (TaskCriteriaPrioritisation criteriaType : TaskCriteriaPrioritisation.values()) {
+			criteriaTypes.put(criteriaType, 0);
+		}
+		return criteriaTypes;
+	}
+
+	/**
+	 * @return hashMap of criterias with double default 1.0
+	 */
+	public static EnumMap<TaskCriteriaPrioritisation, Double> toDoubleEnumMap() {
+		EnumMap<TaskCriteriaPrioritisation, Double> criteriaTypes = new EnumMap<>(TaskCriteriaPrioritisation.class);
+		for (TaskCriteriaPrioritisation criteriaType : TaskCriteriaPrioritisation.values()) {
+			criteriaTypes.put(criteriaType, 1.0);
+		}
+		return criteriaTypes;
+	}
+
+	/**
+	 * Convert all criterias to strings.
+	 *
+	 * @return list of criterias  as Strings.
+	 */
+	public static List<String> toList() {
+		List<String> criteriaTypes = new ArrayList<String>();
+		for (TaskCriteriaPrioritisation criteriaType : TaskCriteriaPrioritisation.values()) {
+			criteriaTypes.add(criteriaType.toString());
+		}
+		return criteriaTypes;
+	}
+
+	/**
+	 * @return list of criterias.
+	 */
+	public static List<TaskCriteriaPrioritisation> getOriginalList() {
+		return new ArrayList<TaskCriteriaPrioritisation>(Arrays.asList(TaskCriteriaPrioritisation.values()));
+	}
+
+}

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/releasenotes/impl/ReleaseNoteConfigurationImpl.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/releasenotes/impl/ReleaseNoteConfigurationImpl.java
@@ -1,0 +1,122 @@
+package de.uhd.ifi.se.decision.management.jira.releasenotes.impl;
+
+
+import de.uhd.ifi.se.decision.management.jira.releasenotes.ReleaseNoteConfiguration;
+import de.uhd.ifi.se.decision.management.jira.releasenotes.TargetGroup;
+import de.uhd.ifi.se.decision.management.jira.releasenotes.TaskCriteriaPrioritisation;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+import java.util.EnumMap;
+import java.util.List;
+
+/**
+ * Model class for Release Notes Configuration
+ */
+public class ReleaseNoteConfigurationImpl implements ReleaseNoteConfiguration {
+	private String startDate;
+	private String endDate;
+	private String sprintId;
+	private TargetGroup targetGroup;
+	private EnumMap<TaskCriteriaPrioritisation, Double> taskCriteriaPrioritisation;
+	private List<Integer> bugFixMapping;
+	private List<Integer> featureMapping;
+	private List<Integer> improvementMapping;
+
+
+	// This default constructor is necessary for the JSON string to object mapping.
+	// Do not delete it!
+	public ReleaseNoteConfigurationImpl() {
+		this.targetGroup = TargetGroup.getTargetGroup("");
+		this.taskCriteriaPrioritisation = TaskCriteriaPrioritisation.toDoubleEnumMap();
+	}
+
+
+	@Override
+	public String getStartDate() {
+		return this.startDate;
+	}
+
+	@Override
+	@JsonProperty("startDate")
+	public void setStartDate(String startDate) {
+		this.startDate = startDate;
+	}
+
+	@Override
+	public String getEndDate() {
+		return this.endDate;
+	}
+
+
+	@Override
+	@JsonProperty("endDate")
+	public void setEndDate(String endDate) {
+		this.endDate = endDate;
+	}
+
+	@Override
+	public String getSprintId() {
+		return this.sprintId;
+	}
+
+	@Override
+	@JsonProperty("sprintId")
+	public void setSprintId(String sprintId) {
+		this.sprintId = sprintId;
+	}
+
+	@Override
+	public TargetGroup getTargetGroup() {
+		return this.targetGroup;
+	}
+
+	@Override
+	@JsonProperty("targetGroup")
+	public void setTargetGroup(TargetGroup targetGroup) {
+		this.targetGroup = targetGroup;
+	}
+
+	@Override
+	public EnumMap<TaskCriteriaPrioritisation, Double> getTaskCriteriaPrioritisation() {
+		return this.taskCriteriaPrioritisation;
+	}
+
+	@Override
+	public void setTaskCriteriaPrioritisation(EnumMap<TaskCriteriaPrioritisation, Double> taskCriteriaPrioritisation) {
+		this.taskCriteriaPrioritisation = taskCriteriaPrioritisation;
+	}
+
+	@Override
+	public List<Integer> getBugFixMapping() {
+		return this.bugFixMapping;
+	}
+
+	@Override
+	@JsonProperty("bugFixMapping")
+	public void setBugFixMapping(List<Integer> bugFixMapping) {
+		this.bugFixMapping = bugFixMapping;
+	}
+
+	@Override
+	public List<Integer> getFeatureMapping() {
+		return this.featureMapping;
+	}
+
+	@Override
+	@JsonProperty("featureMapping")
+	public void setFeatureMapping(List<Integer> featureMapping) {
+		this.featureMapping = featureMapping;
+	}
+
+	@Override
+	public List<Integer> getImprovementMapping() {
+		return this.improvementMapping;
+	}
+
+	@Override
+	@JsonProperty("improvementMapping")
+	public void setImprovementMapping(List<Integer> improvementMapping) {
+		this.improvementMapping = improvementMapping;
+	}
+
+}

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/releasenotes/impl/ReleaseNoteImpl.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/releasenotes/impl/ReleaseNoteImpl.java
@@ -1,0 +1,66 @@
+package de.uhd.ifi.se.decision.management.jira.releasenotes.impl;
+
+
+import de.uhd.ifi.se.decision.management.jira.model.DecisionKnowledgeProject;
+import de.uhd.ifi.se.decision.management.jira.model.impl.DecisionKnowledgeProjectImpl;
+import de.uhd.ifi.se.decision.management.jira.releasenotes.ReleaseNote;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+/**
+ * Model class for Release Notes
+ */
+public class ReleaseNoteImpl implements ReleaseNote {
+
+	private long id;
+	private String title;
+	private String content;
+	private DecisionKnowledgeProject project;
+
+
+	@Override
+	public long getId() {
+		return this.id;
+	}
+
+	@Override
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	@Override
+	public String getTitle() {
+		return this.title;
+	}
+
+	@Override
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	@Override
+	public DecisionKnowledgeProject getProject() {
+		return this.project;
+	}
+
+	@Override
+	public void setProject(DecisionKnowledgeProject project) {
+		this.project = project;
+	}
+
+	@Override
+	@JsonProperty("projectKey")
+	public void setProject(String projectKey) {
+		this.project = new DecisionKnowledgeProjectImpl(projectKey);
+	}
+
+	@Override
+	public String getContent() {
+		return this.content;
+	}
+
+	@Override
+	public void setContent(String content) {
+		this.content = content;
+	}
+
+}

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/releasenotes/impl/ReleaseNoteIssueProposalImpl.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/releasenotes/impl/ReleaseNoteIssueProposalImpl.java
@@ -1,0 +1,93 @@
+package de.uhd.ifi.se.decision.management.jira.releasenotes.impl;
+
+import de.uhd.ifi.se.decision.management.jira.model.DecisionKnowledgeElement;
+import de.uhd.ifi.se.decision.management.jira.releasenotes.ReleaseNoteIssueProposal;
+import de.uhd.ifi.se.decision.management.jira.releasenotes.TaskCriteriaPrioritisation;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+import javax.xml.bind.annotation.XmlElement;
+import java.util.EnumMap;
+
+
+/**
+ * Model class Release Note Issue Proposal
+ * It saves the decision knowledge element, the final rating and the task criteria prioritisation metrics.
+ */
+public class ReleaseNoteIssueProposalImpl implements ReleaseNoteIssueProposal {
+
+	private DecisionKnowledgeElement decisionKnowledgeElement;
+
+	private EnumMap<TaskCriteriaPrioritisation, Integer> taskCriteriaPrioritisation;
+	private double rating;
+
+	/**
+	 * Constructer to initialize default values and add count of DK
+	 *
+	 * @param decisionKnowledgeElement
+	 * @param countDecisionKnowledge
+	 */
+	public ReleaseNoteIssueProposalImpl(DecisionKnowledgeElement decisionKnowledgeElement, int countDecisionKnowledge) {
+		this.decisionKnowledgeElement = decisionKnowledgeElement;
+		//set default values
+		this.taskCriteriaPrioritisation = TaskCriteriaPrioritisation.toIntegerEnumMap();
+		this.taskCriteriaPrioritisation.put(TaskCriteriaPrioritisation.COUNT_DECISION_KNOWLEDGE, countDecisionKnowledge);
+
+	}
+
+	/**
+	 * @return decisionKnowledgeElement of the ReleaseNoteIssueProposal
+	 */
+	@Override
+	@XmlElement(name = "decisionKnowledgeElement")
+	public DecisionKnowledgeElement getDecisionKnowledgeElement() {
+		return this.decisionKnowledgeElement;
+	}
+
+	/**
+	 * @param decisionKnowledgeElement of the ReleaseNoteIssueProposal.
+	 */
+	@Override
+	@JsonProperty("decisionKnowledgeElement")
+	public void setDecisionKnowledgeElement(DecisionKnowledgeElement decisionKnowledgeElement) {
+		this.decisionKnowledgeElement = decisionKnowledgeElement;
+	}
+
+	/**
+	 * @return rating of the ReleaseNoteIssueProposal
+	 */
+	@Override
+	@XmlElement(name = "rating")
+	public double getRating() {
+		return this.rating;
+	}
+
+	/**
+	 * @param rating of the ReleaseNoteIssueProposal.
+	 */
+	@Override
+	@JsonProperty("rating")
+	public void setRating(double rating) {
+		this.rating = rating;
+	}
+
+	/**
+	 * Get criteria Prioritisation of the ReleaseNoteIssueProposal.
+	 *
+	 * @return taskCriteriaPrioritisation of the ReleaseNoteIssueProposal.
+	 */
+	@Override
+	@XmlElement(name = "taskCriteriaPrioritisation")
+	public EnumMap<TaskCriteriaPrioritisation, Integer> getTaskCriteriaPrioritisation() {
+		return this.taskCriteriaPrioritisation;
+	}
+
+	/**
+	 * set criteria Prioritisation of the ReleaseNoteIssueProposal.
+	 *
+	 * @param taskCriteriaPrioritisation of the ReleaseNoteIssueProposal.
+	 */
+	@Override
+	public void setTaskCriteriaPrioritisation(EnumMap<TaskCriteriaPrioritisation, Integer> taskCriteriaPrioritisation) {
+		this.taskCriteriaPrioritisation = taskCriteriaPrioritisation;
+	}
+}

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/releasenotes/TestReleaseNote.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/releasenotes/TestReleaseNote.java
@@ -1,0 +1,56 @@
+package de.uhd.ifi.se.decision.management.jira.releasenotes;
+
+import de.uhd.ifi.se.decision.management.jira.model.DecisionKnowledgeProject;
+import de.uhd.ifi.se.decision.management.jira.model.impl.DecisionKnowledgeProjectImpl;
+import de.uhd.ifi.se.decision.management.jira.releasenotes.impl.ReleaseNoteImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class TestReleaseNote {
+	private ReleaseNote note;
+	private long id;
+	private String title;
+	private DecisionKnowledgeProject project;
+	private String content;
+	@Before
+	public void setUp(){
+		note=new ReleaseNoteImpl();
+		id=312;
+		title="version 1.0 Great title";
+		String projectKey = "test";
+		project = new DecisionKnowledgeProjectImpl(projectKey);
+		content="<h1>verision</h2>&/=)(09(=)(=)&%kjhkjhaksdjlklöajlaksdfalsdj";
+	}
+
+	@Test
+	public void testId() {
+		note.setId(id);
+		assertEquals(id,note.getId());
+	}
+
+
+	@Test
+	public void testTitle() {
+		note.setTitle(title);
+		assertEquals(title,note.getTitle());
+	}
+
+	@Test
+	public void testProject() {
+		note.setProject(project);
+		assertEquals(project, note.getProject());
+		String projectKey2="test2";
+		note.setProject(projectKey2);
+		assertEquals(projectKey2, note.getProject().getProjectKey());
+	}
+
+
+	@Test
+	public void testContent() {
+		note.setContent(content);
+		assertEquals(content, note.getContent());
+	}
+
+}

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/releasenotes/TestReleaseNoteConfiguration.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/releasenotes/TestReleaseNoteConfiguration.java
@@ -1,0 +1,98 @@
+package de.uhd.ifi.se.decision.management.jira.releasenotes;
+
+import com.atlassian.jira.issue.issuetype.IssueType;
+import de.uhd.ifi.se.decision.management.jira.releasenotes.impl.ReleaseNoteConfigurationImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestReleaseNoteConfiguration {
+	private ReleaseNoteConfiguration config;
+	private String startDate;
+	private String endDate;
+	private String sprintId;
+	private TargetGroup targetGroup;
+	private EnumMap<TaskCriteriaPrioritisation, Double> taskCriteriaPrioritisation;
+	private List<Integer> bugFixMapping;
+	private List<Integer> featureMapping;
+	private List<Integer> improvementMapping;
+	private IssueType issueType;
+
+	@Before
+	public void setUp() {
+		config = new ReleaseNoteConfigurationImpl();
+		startDate = "2019-01-12";
+		endDate = "2020-01-12";
+		sprintId = "15";
+		targetGroup = TargetGroup.DEVELOPER;
+		taskCriteriaPrioritisation = TaskCriteriaPrioritisation.toDoubleEnumMap();
+		bugFixMapping = new ArrayList<Integer>();
+		featureMapping = new ArrayList<Integer>();
+		improvementMapping = new ArrayList<Integer>();
+		bugFixMapping.add(1);
+		featureMapping.add(2);
+		improvementMapping.add(3);
+	}
+
+	@Test
+	public void testStartDate() {
+		config.setStartDate(startDate);
+		assertEquals(startDate, config.getStartDate());
+	}
+
+
+	@Test
+	public void testEndDate() {
+		config.setEndDate(endDate);
+		assertEquals(endDate, config.getEndDate());
+	}
+
+
+	@Test
+	public void testSprintId() {
+		config.setSprintId(sprintId);
+		assertEquals(sprintId, config.getSprintId());
+
+	}
+
+
+	@Test
+	public void testTargetGroup() {
+		config.setTargetGroup(targetGroup);
+		assertEquals(targetGroup, config.getTargetGroup());
+	}
+
+
+	@Test
+	public void testTaskCriteriaPrioritisation() {
+		config.setTaskCriteriaPrioritisation(taskCriteriaPrioritisation);
+		assertEquals(taskCriteriaPrioritisation, config.getTaskCriteriaPrioritisation());
+	}
+
+	@Test
+	public void testBugFixMapping() {
+		config.setBugFixMapping(bugFixMapping);
+		assertEquals(bugFixMapping, config.getBugFixMapping());
+
+	}
+
+
+	@Test
+	public void testFeatureMapping() {
+		config.setFeatureMapping(featureMapping);
+		assertEquals(featureMapping, config.getFeatureMapping());
+
+	}
+
+	@Test
+	public void testImprovementMapping() {
+		config.setImprovementMapping(improvementMapping);
+		assertEquals(improvementMapping, config.getImprovementMapping());
+	}
+
+}

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/releasenotes/TestReleaseNoteIssueProposal.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/releasenotes/TestReleaseNoteIssueProposal.java
@@ -1,0 +1,66 @@
+package de.uhd.ifi.se.decision.management.jira.releasenotes;
+
+import de.uhd.ifi.se.decision.management.jira.model.DecisionKnowledgeElement;
+import de.uhd.ifi.se.decision.management.jira.model.impl.DecisionKnowledgeElementImpl;
+import de.uhd.ifi.se.decision.management.jira.releasenotes.impl.ReleaseNoteIssueProposalImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.EnumMap;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestReleaseNoteIssueProposal {
+	private long idOfDKElement;
+	private ReleaseNoteIssueProposal proposal;
+	private double rating;
+
+	@Before
+	public void setUp() {
+		idOfDKElement = 14;
+		DecisionKnowledgeElement dkElement = new DecisionKnowledgeElementImpl();
+		dkElement.setId(idOfDKElement);
+		proposal = new ReleaseNoteIssueProposalImpl(dkElement, 3);
+		rating = 54.21;
+		proposal.setRating(rating);
+	}
+
+	@Test
+	public void testGetDecisionKnowledgeElement() {
+		assertEquals(idOfDKElement, proposal.getDecisionKnowledgeElement().getId());
+	}
+
+	@Test
+	public void testSetDecisionKnowledgeElement() {
+		DecisionKnowledgeElement dkElement2 = new DecisionKnowledgeElementImpl();
+		dkElement2.setId(15);
+		proposal.setDecisionKnowledgeElement(dkElement2);
+		assertEquals(15, proposal.getDecisionKnowledgeElement().getId());
+	}
+
+	@Test
+	public void testGetRating() {
+		assertEquals(rating, proposal.getRating(), 0.0);
+	}
+
+	@Test
+	public void testSetRating() {
+		double rating2 = 32.653;
+		proposal.setRating(rating2);
+		assertEquals(rating2, proposal.getRating(), 0.0);
+	}
+
+	@Test
+	public void testGetTaskCriteriaPrioritisation() {
+		assertEquals(8, proposal.getTaskCriteriaPrioritisation().size());
+
+	}
+
+	@Test
+	public void testSetTaskCriteriaPrioritisation() {
+		EnumMap<TaskCriteriaPrioritisation, Integer> taskCriteriaPrioritisation = TaskCriteriaPrioritisation.toIntegerEnumMap();
+		taskCriteriaPrioritisation.put(TaskCriteriaPrioritisation.DAYS_COMPLETION, 135);
+		proposal.setTaskCriteriaPrioritisation(taskCriteriaPrioritisation);
+		assertEquals(135, proposal.getTaskCriteriaPrioritisation().get(TaskCriteriaPrioritisation.DAYS_COMPLETION), 0.0);
+	}
+}

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/releasenotes/TestTargetGroup.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/releasenotes/TestTargetGroup.java
@@ -1,0 +1,20 @@
+package de.uhd.ifi.se.decision.management.jira.releasenotes;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestTargetGroup {
+
+	@Test
+	public void testToString() {
+		assertEquals("stakeholder", TargetGroup.STAKEHOLDER.toString());
+	}
+
+	@Test
+	public void testGetTargetGroup() {
+		assertEquals(TargetGroup.STAKEHOLDER, TargetGroup.getTargetGroup("stakeholder"));
+		assertEquals(TargetGroup.DEVELOPER, TargetGroup.getTargetGroup(null));
+
+	}
+}

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/releasenotes/TestTaskCriteriaPrioritisation.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/releasenotes/TestTaskCriteriaPrioritisation.java
@@ -1,0 +1,42 @@
+package de.uhd.ifi.se.decision.management.jira.releasenotes;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestTaskCriteriaPrioritisation {
+
+	@Test
+	public void testToString() {
+		assertEquals("count_decision_knowledge", TaskCriteriaPrioritisation.COUNT_DECISION_KNOWLEDGE.toString());
+	}
+
+	@Test
+	public void getTaskCriteriaPrioritisation() {
+		assertEquals(TaskCriteriaPrioritisation.COUNT_DECISION_KNOWLEDGE, TaskCriteriaPrioritisation.getTaskCriteriaPrioritisation("count_decision_knowledge"));
+		assertEquals(TaskCriteriaPrioritisation.COUNT_DECISION_KNOWLEDGE, TaskCriteriaPrioritisation.getTaskCriteriaPrioritisation(null));
+	}
+
+	@Test
+	public void toIntegerEnumMap() {
+		assertEquals(8, TaskCriteriaPrioritisation.toIntegerEnumMap().size(), 0.0);
+		assertEquals(0, TaskCriteriaPrioritisation.toIntegerEnumMap().get(TaskCriteriaPrioritisation.COUNT_DECISION_KNOWLEDGE), 0.0);
+
+	}
+
+	@Test
+	public void toDoubleEnumMap() {
+		assertEquals(8, TaskCriteriaPrioritisation.toDoubleEnumMap().size(), 0.0);
+		assertEquals(1.0, TaskCriteriaPrioritisation.toDoubleEnumMap().get(TaskCriteriaPrioritisation.COUNT_DECISION_KNOWLEDGE), 0.0);
+	}
+
+	@Test
+	public void toList() {
+		assertEquals(8, TaskCriteriaPrioritisation.toIntegerEnumMap().size(), 0.0);
+	}
+
+	@Test
+	public void getOriginalList() {
+		assertEquals(8, TaskCriteriaPrioritisation.toIntegerEnumMap().size(), 0.0);
+	}
+}


### PR DESCRIPTION
ConDec-558: add model classes and interfaces for:
- release note configuration
- issue proposal
- release notes