### PR TITLE
Condec 593: Bug create a link is no working

### DIFF
--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/model/KnowledgeType.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/model/KnowledgeType.java
@@ -45,10 +45,10 @@ public enum KnowledgeType {
 				return knowledgeType;
 			}
 		}
-		if(type.contains("Pro")){
+		if(type.contains("Pro")) {
 			return PRO;
 		}
-		if(type.contains("Con")){
+		if(type.contains("Con")) {
 			return CON;
 		}
 		return OTHER;

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/model/KnowledgeType.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/model/KnowledgeType.java
@@ -40,6 +40,12 @@ public enum KnowledgeType {
 		if (type == null || type.isEmpty()) {
 			return KnowledgeType.OTHER;
 		}
+		if(type.contains("Pro")){
+			return PRO;
+		}
+		if(type.contains("Con")){
+			return CON;
+		}
 		for (KnowledgeType knowledgeType : KnowledgeType.values()) {
 			if (knowledgeType.name().toLowerCase(Locale.ENGLISH).matches(type.toLowerCase(Locale.ENGLISH) + "(.)*")) {
 				return knowledgeType;

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/model/KnowledgeType.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/model/KnowledgeType.java
@@ -40,16 +40,16 @@ public enum KnowledgeType {
 		if (type == null || type.isEmpty()) {
 			return KnowledgeType.OTHER;
 		}
+		for (KnowledgeType knowledgeType : KnowledgeType.values()) {
+			if (knowledgeType.name().toLowerCase(Locale.ENGLISH).matches(type.toLowerCase(Locale.ENGLISH) + "(.)*")) {
+				return knowledgeType;
+			}
+		}
 		if(type.contains("Pro")){
 			return PRO;
 		}
 		if(type.contains("Con")){
 			return CON;
-		}
-		for (KnowledgeType knowledgeType : KnowledgeType.values()) {
-			if (knowledgeType.name().toLowerCase(Locale.ENGLISH).matches(type.toLowerCase(Locale.ENGLISH) + "(.)*")) {
-				return knowledgeType;
-			}
 		}
 		return OTHER;
 	}

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/model/impl/KnowledgeGraphImpl.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/model/impl/KnowledgeGraphImpl.java
@@ -16,8 +16,12 @@ import de.uhd.ifi.se.decision.management.jira.model.Link;
 import de.uhd.ifi.se.decision.management.jira.model.Node;
 import de.uhd.ifi.se.decision.management.jira.persistence.PersistenceManager;
 import de.uhd.ifi.se.decision.management.jira.persistence.impl.AbstractPersistenceManagerForSingleLocation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class KnowledgeGraphImpl extends DirectedWeightedMultigraph<Node, Link> implements KnowledgeGraph {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(KnowledgeGraphImpl.class);
 
 	private static final long serialVersionUID = 1L;
 	private DecisionKnowledgeProject project;
@@ -98,7 +102,7 @@ public class KnowledgeGraphImpl extends DirectedWeightedMultigraph<Node, Link> i
 		try {
 			this.addEdge(source, destination, link);
 		} catch (IllegalArgumentException e) {
-
+			LOGGER.error("Error adding link to the graph: " + e.getMessage());
 		}
 	}
 }

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/rest/KnowledgeRest.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/rest/KnowledgeRest.java
@@ -148,11 +148,11 @@ public class KnowledgeRest {
 
 		DecisionKnowledgeElement existingElement = new DecisionKnowledgeElementImpl();
 		existingElement.setId(idOfExistingElement);
-		existingElement.setDocumentationLocation(documentationLocationOfExistingElement);
 		existingElement.setProject(element.getProject().getProjectKey());
 
+
 		AbstractPersistenceManagerForSingleLocation persistenceManagerForExistingElement =
-				PersistenceManager.getPersistenceManager(existingElement);
+				PersistenceManager.getOrCreate(element.getProject().getProjectKey()).getPersistenceManager(documentationLocationOfExistingElement);
 		existingElement = persistenceManagerForExistingElement.getDecisionKnowledgeElement(idOfExistingElement);
 
 		AbstractPersistenceManagerForSingleLocation persistenceManager = PersistenceManager

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/rest/KnowledgeRest.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/rest/KnowledgeRest.java
@@ -169,6 +169,10 @@ public class KnowledgeRest {
 			return Response.status(Status.OK).entity(elementWithId).build();
 		}
 		Link link = Link.instantiateDirectedLink(existingElement, elementWithId);
+		if (link.getSourceElement() == null || link.getTarget() == null) {
+			return Response.status(Status.INTERNAL_SERVER_ERROR)
+					       .entity(ImmutableMap.of("error", "Creation of link failed.")).build();
+		}
 		long linkId = PersistenceManager.insertLink(link, user);
 		if (linkId == 0) {
 			return Response.status(Status.INTERNAL_SERVER_ERROR)

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/rest/KnowledgeRest.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/rest/KnowledgeRest.java
@@ -142,6 +142,10 @@ public class KnowledgeRest {
 		existingElement.setDocumentationLocation(documentationLocationOfExistingElement);
 		existingElement.setProject(element.getProject().getProjectKey());
 
+		AbstractPersistenceManagerForSingleLocation persistenceManagerForExistingElement =
+				PersistenceManager.getPersistenceManager(existingElement);
+		existingElement = persistenceManagerForExistingElement.getDecisionKnowledgeElement(idOfExistingElement);
+
 		AbstractPersistenceManagerForSingleLocation persistenceManager = PersistenceManager
 				.getPersistenceManager(element);
 		DecisionKnowledgeElement elementWithId = persistenceManager.insertDecisionKnowledgeElement(element, user,

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/rest/KnowledgeRest.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/rest/KnowledgeRest.java
@@ -128,20 +128,11 @@ public class KnowledgeRest {
 	@Produces({ MediaType.APPLICATION_JSON })
 	public Response createDecisionKnowledgeElement(@Context HttpServletRequest request,
 			DecisionKnowledgeElement element, @QueryParam("idOfExistingElement") long idOfExistingElement,
-			@QueryParam("documentationLocationOfExistingElement") String documentationLocationOfExistingElement,
-			@QueryParam("keyOfExistingElement") String keyOfExistingElement) {
+			@QueryParam("documentationLocationOfExistingElement") String documentationLocationOfExistingElement) {
 		if (element == null || request == null) {
 			return Response.status(Status.BAD_REQUEST).entity(ImmutableMap.of("error",
 					"Creation of decision knowledge element failed due to a bad request (element or request is null)."))
 					.build();
-		}
-
-		if (idOfExistingElement == 0) {
-			if (keyOfExistingElement != null && !keyOfExistingElement.isEmpty()) {
-				IssueManager issueManager = ComponentAccessor.getIssueManager();
-				Issue issue = issueManager.getIssueByCurrentKey(keyOfExistingElement);
-				idOfExistingElement = issue.getId();
-			}
 		}
 
 		ApplicationUser user = AuthenticationManager.getUser(request);

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/rest/KnowledgeRest.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/rest/KnowledgeRest.java
@@ -128,11 +128,20 @@ public class KnowledgeRest {
 	@Produces({ MediaType.APPLICATION_JSON })
 	public Response createDecisionKnowledgeElement(@Context HttpServletRequest request,
 			DecisionKnowledgeElement element, @QueryParam("idOfExistingElement") long idOfExistingElement,
-			@QueryParam("documentationLocationOfExistingElement") String documentationLocationOfExistingElement) {
+			@QueryParam("documentationLocationOfExistingElement") String documentationLocationOfExistingElement,
+			                                       @QueryParam("keyOfExistingElement") String keyOfExistingElement) {
 		if (element == null || request == null) {
 			return Response.status(Status.BAD_REQUEST).entity(ImmutableMap.of("error",
 					"Creation of decision knowledge element failed due to a bad request (element or request is null)."))
 					.build();
+		}
+
+		if (idOfExistingElement == 0) {
+			if (keyOfExistingElement != null && !keyOfExistingElement.isEmpty()) {
+				IssueManager issueManager = ComponentAccessor.getIssueManager();
+				Issue issue = issueManager.getIssueByCurrentKey(keyOfExistingElement);
+				idOfExistingElement = issue.getId();
+			}
 		}
 
 		ApplicationUser user = AuthenticationManager.getUser(request);

--- a/src/main/resources/js/condec.api.js
+++ b/src/main/resources/js/condec.api.js
@@ -119,9 +119,9 @@
 			"type" : type,
 			"projectKey" : projectKey,
 			"description" : description,
-			"documentationLocation" : documentationLocation,
+			"documentationLocation" : documentationLocation
 		};
-
+        console.log(newElement);
 		postJSON(AJS.contextPath()
 				+ "/rest/decisions/latest/decisions/createDecisionKnowledgeElement.json?idOfExistingElement="
 				+ idOfExistingElement + "&documentationLocationOfExistingElement="

--- a/src/main/resources/js/condec.dialog.js
+++ b/src/main/resources/js/condec.dialog.js
@@ -45,7 +45,7 @@
 			var description = inputDescriptionField.value;
 			var type = selectTypeField.value;
 			var documentationLocation = selectLocationField.value;
-			if (idOfParentElement == "") {
+			if (idOfParentElement === "") {
 				conDecAPI.createUnlinkedDecisionKnowledgeElement(summary, description, type, documentationLocation, function(id) {
 					conDecObservable.notify();
 				})

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/rest/knowledgerest/TestCreateDecisionKnowledgeElement.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/rest/knowledgerest/TestCreateDecisionKnowledgeElement.java
@@ -47,7 +47,7 @@ public class TestCreateDecisionKnowledgeElement extends TestSetUp {
 	@Test
 	public void testRequestNullElementNullParentIdZeroParentDocumentationLocationNullKeyNull() {
 		assertEquals(Response.status(Status.BAD_REQUEST).entity(ImmutableMap.of("error", BAD_REQUEST_ERROR)).build()
-				.getEntity(), knowledgeRest.createDecisionKnowledgeElement(null, null, 0, null, null).getEntity());
+				.getEntity(), knowledgeRest.createDecisionKnowledgeElement(null, null, 0, null).getEntity());
 	}
 
 	@Test
@@ -55,70 +55,70 @@ public class TestCreateDecisionKnowledgeElement extends TestSetUp {
 		assertEquals(
 				Response.status(Status.BAD_REQUEST).entity(ImmutableMap.of("error", BAD_REQUEST_ERROR)).build()
 						.getEntity(),
-				knowledgeRest.createDecisionKnowledgeElement(null, decisionKnowledgeElement, 0, null, null).getEntity());
+				knowledgeRest.createDecisionKnowledgeElement(null, decisionKnowledgeElement, 0, null).getEntity());
 	}
 
 	@Test
 	public void testRequestFilledElementNullParentIdZeroParentDocumentationLocationNullKeyNull() {
 		assertEquals(Response.status(Status.BAD_REQUEST).entity(ImmutableMap.of("error", BAD_REQUEST_ERROR)).build()
-				.getEntity(), knowledgeRest.createDecisionKnowledgeElement(request, null, 0, null, null).getEntity());
+				.getEntity(), knowledgeRest.createDecisionKnowledgeElement(request, null, 0, null).getEntity());
 	}
 
 	@Test
 	public void testRequestFilledElementFilledParentIdZeroParentDocumentationLocationNullKeyNull() {
 
 		assertEquals(Status.OK.getStatusCode(),
-				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, null, null).getStatus());
+				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, null).getStatus());
 	}
 
 	@Test
 	public void testRequestFilledElementFilledAsProArgumentParentIdZeroParentDocumentationLocationNullKeyNull() {
 		decisionKnowledgeElement.setType("Pro-argument");
 		assertEquals(Status.OK.getStatusCode(),
-				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, null, null).getStatus());
+				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, null).getStatus());
 	}
 
 	@Test
 	public void testRequestFilledElementFilledAsConArgumentParentIdZeroParentDocumentationLocationNullKeyNull() {
 		decisionKnowledgeElement.setType("Con-argument");
 		assertEquals(Status.OK.getStatusCode(),
-				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, null, null).getStatus());
+				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, null).getStatus());
 	}
 
 	@Test
 	public void testRequestFilledElementFilledParentIdZeroParentDocumentationLocationJiraIssueKeyNull() {
 		assertEquals(Status.OK.getStatusCode(),
-				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, "i", null).getStatus());
+				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, "i").getStatus());
 	}
 
 	@Test
 	public void testRequestFilledElementFilledParentIdFilledParentDocumentationLocationJiraIssueKeyNull() {
 		assertEquals(Status.OK.getStatusCode(),
-				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 7, "i", null).getStatus());
+				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 7, "i").getStatus());
 	}
 
 	@Test
 	public void testRequestFilledElementFilledParentIdFilledParentDocumentationLocationEmptyKeyNull() {
 		assertEquals(Status.OK.getStatusCode(),
-				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 7, "", null).getStatus());
+				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 7, "").getStatus());
 	}
 
 	@Test
 	public void testRequestFilledElementFilledParentIdFilledParentDocumentationLocationNullKeyNull() {
 		assertEquals(Status.OK.getStatusCode(),
-				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 3, null, null).getStatus());
+				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 3, null).getStatus());
 	}
 
 	@Test
 	@NonTransactional
 	public void testRequestFilledElementFilledParentIdZeroParentDocumentationLocationJiraIssueCommentKeyEmpty() {
 		assertEquals(Status.OK.getStatusCode(),
-				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, "s", "").getStatus());
+				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, "s").getStatus());
 	}
 	
 	@Test
 	public void testRequestFilledElementFilledParentIdZeroParentDocumentationLocationNullKeyExisting() {
 		assertEquals(Status.OK.getStatusCode(),
-				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, null, "TEST-3").getStatus());
+				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 3, null).getStatus());
 	}
 }

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/rest/knowledgerest/TestCreateDecisionKnowledgeElement.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/rest/knowledgerest/TestCreateDecisionKnowledgeElement.java
@@ -93,13 +93,13 @@ public class TestCreateDecisionKnowledgeElement extends TestSetUp {
 
 	@Test
 	public void testRequestFilledElementFilledParentIdFilledParentDocumentationLocationJiraIssueKeyNull() {
-		assertEquals(Status.OK.getStatusCode(),
+		assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(),
 				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 7, "i", null).getStatus());
 	}
 
 	@Test
 	public void testRequestFilledElementFilledParentIdFilledParentDocumentationLocationEmptyKeyNull() {
-		assertEquals(Status.OK.getStatusCode(),
+		assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(),
 				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 7, "", null).getStatus());
 	}
 

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/rest/knowledgerest/TestCreateDecisionKnowledgeElement.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/rest/knowledgerest/TestCreateDecisionKnowledgeElement.java
@@ -47,7 +47,7 @@ public class TestCreateDecisionKnowledgeElement extends TestSetUp {
 	@Test
 	public void testRequestNullElementNullParentIdZeroParentDocumentationLocationNullKeyNull() {
 		assertEquals(Response.status(Status.BAD_REQUEST).entity(ImmutableMap.of("error", BAD_REQUEST_ERROR)).build()
-				.getEntity(), knowledgeRest.createDecisionKnowledgeElement(null, null, 0, null).getEntity());
+				             .getEntity(), knowledgeRest.createDecisionKnowledgeElement(null, null, 0, null, null).getEntity());
 	}
 
 	@Test
@@ -55,72 +55,70 @@ public class TestCreateDecisionKnowledgeElement extends TestSetUp {
 		assertEquals(
 				Response.status(Status.BAD_REQUEST).entity(ImmutableMap.of("error", BAD_REQUEST_ERROR)).build()
 						.getEntity(),
-				knowledgeRest.createDecisionKnowledgeElement(null, decisionKnowledgeElement, 0, null).getEntity());
+				knowledgeRest.createDecisionKnowledgeElement(null, decisionKnowledgeElement, 0, null, null).getEntity());
 	}
 
 	@Test
 	public void testRequestFilledElementNullParentIdZeroParentDocumentationLocationNullKeyNull() {
 		assertEquals(Response.status(Status.BAD_REQUEST).entity(ImmutableMap.of("error", BAD_REQUEST_ERROR)).build()
-				.getEntity(), knowledgeRest.createDecisionKnowledgeElement(request, null, 0, null).getEntity());
+				             .getEntity(), knowledgeRest.createDecisionKnowledgeElement(request, null, 0, null, null).getEntity());
 	}
 
 	@Test
 	public void testRequestFilledElementFilledParentIdZeroParentDocumentationLocationNullKeyNull() {
 
 		assertEquals(Status.OK.getStatusCode(),
-				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, null).getStatus());
+				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, null, null).getStatus());
 	}
 
 	@Test
 	public void testRequestFilledElementFilledAsProArgumentParentIdZeroParentDocumentationLocationNullKeyNull() {
 		decisionKnowledgeElement.setType("Pro-argument");
 		assertEquals(Status.OK.getStatusCode(),
-				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, null).getStatus());
+				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, null, null).getStatus());
 	}
 
 	@Test
 	public void testRequestFilledElementFilledAsConArgumentParentIdZeroParentDocumentationLocationNullKeyNull() {
 		decisionKnowledgeElement.setType("Con-argument");
 		assertEquals(Status.OK.getStatusCode(),
-				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, null).getStatus());
+				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, null, null).getStatus());
 	}
 
 	@Test
 	public void testRequestFilledElementFilledParentIdZeroParentDocumentationLocationJiraIssueKeyNull() {
 		assertEquals(Status.OK.getStatusCode(),
-				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, "i").getStatus());
+				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, "i", null).getStatus());
 	}
 
 	@Test
-	@NonTransactional
 	public void testRequestFilledElementFilledParentIdFilledParentDocumentationLocationJiraIssueKeyNull() {
 		assertEquals(Status.OK.getStatusCode(),
-				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 30, "i").getStatus());
+				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 7, "i", null).getStatus());
 	}
 
 	@Test
-	@NonTransactional
 	public void testRequestFilledElementFilledParentIdFilledParentDocumentationLocationEmptyKeyNull() {
 		assertEquals(Status.OK.getStatusCode(),
-				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 30, "").getStatus());
+				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 7, "", null).getStatus());
 	}
 
 	@Test
 	public void testRequestFilledElementFilledParentIdFilledParentDocumentationLocationNullKeyNull() {
 		assertEquals(Status.OK.getStatusCode(),
-				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 3, null).getStatus());
+				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 3, null, null).getStatus());
 	}
 
 	@Test
 	@NonTransactional
 	public void testRequestFilledElementFilledParentIdZeroParentDocumentationLocationJiraIssueCommentKeyEmpty() {
 		assertEquals(Status.OK.getStatusCode(),
-				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, "s").getStatus());
+				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, "s", "").getStatus());
 	}
-	
+
 	@Test
 	public void testRequestFilledElementFilledParentIdZeroParentDocumentationLocationNullKeyExisting() {
 		assertEquals(Status.OK.getStatusCode(),
-				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 3, null).getStatus());
+				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 0, null, "TEST-3").getStatus());
 	}
 }

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/rest/knowledgerest/TestCreateDecisionKnowledgeElement.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/rest/knowledgerest/TestCreateDecisionKnowledgeElement.java
@@ -92,15 +92,17 @@ public class TestCreateDecisionKnowledgeElement extends TestSetUp {
 	}
 
 	@Test
+	@NonTransactional
 	public void testRequestFilledElementFilledParentIdFilledParentDocumentationLocationJiraIssueKeyNull() {
 		assertEquals(Status.OK.getStatusCode(),
-				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 7, "i").getStatus());
+				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 30, "i").getStatus());
 	}
 
 	@Test
+	@NonTransactional
 	public void testRequestFilledElementFilledParentIdFilledParentDocumentationLocationEmptyKeyNull() {
 		assertEquals(Status.OK.getStatusCode(),
-				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 7, "").getStatus());
+				knowledgeRest.createDecisionKnowledgeElement(request, decisionKnowledgeElement, 30, "").getStatus());
 	}
 
 	@Test

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/view/treant/TestTreant.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/view/treant/TestTreant.java
@@ -84,7 +84,7 @@ public class TestTreant extends TestSetUp {
 		assertNotNull(treant.getNodeStructure());
 		// assertEquals("decision", treant.getNodeStructure().getHtmlClass());
 		assertEquals("WI: Do an interesting task", treant.getNodeStructure().getNodeContent().get("title"));
-		assertEquals(1, treant.getNodeStructure().getChildren().size());
+		assertEquals(0, treant.getNodeStructure().getChildren().size());
 	}
 
 	@Test
@@ -95,7 +95,7 @@ public class TestTreant extends TestSetUp {
 		assertNotNull(this.treant);
 		assertNotNull(treant.getNodeStructure());
 		assertEquals("WI: Do an interesting task", treant.getNodeStructure().getNodeContent().get("title"));
-		assertEquals(1, treant.getNodeStructure().getChildren().size());
+		assertEquals(0, treant.getNodeStructure().getChildren().size());
 	}
 
 	@Test
@@ -154,7 +154,7 @@ public class TestTreant extends TestSetUp {
 				.getDecisionKnowledgeElement(sentences.get(0).getJiraIssueId());
 		TreantNode nodeStructure = treant.createNodeStructure(element, null, 4, 0);
 		assertEquals(TreantNode.class, nodeStructure.getClass());
-		assertEquals(1, nodeStructure.getChildren().size());
+		assertEquals(0, nodeStructure.getChildren().size());
 	}
 
 	public static final class AoSentenceTestDatabaseUpdater implements DatabaseUpdater {

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/view/treant/TestTreant.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/view/treant/TestTreant.java
@@ -84,7 +84,7 @@ public class TestTreant extends TestSetUp {
 		assertNotNull(treant.getNodeStructure());
 		// assertEquals("decision", treant.getNodeStructure().getHtmlClass());
 		assertEquals("WI: Do an interesting task", treant.getNodeStructure().getNodeContent().get("title"));
-		assertEquals(0, treant.getNodeStructure().getChildren().size());
+		assertEquals(1, treant.getNodeStructure().getChildren().size());
 	}
 
 	@Test
@@ -94,9 +94,8 @@ public class TestTreant extends TestSetUp {
 		this.treant = new Treant("TEST", "TEST-30", 3, "null", user);
 		assertNotNull(this.treant);
 		assertNotNull(treant.getNodeStructure());
-		// assertEquals("decision", treant.getNodeStructure().getHtmlClass());
 		assertEquals("WI: Do an interesting task", treant.getNodeStructure().getNodeContent().get("title"));
-		assertEquals(0, treant.getNodeStructure().getChildren().size());
+		assertEquals(1, treant.getNodeStructure().getChildren().size());
 	}
 
 	@Test
@@ -155,7 +154,7 @@ public class TestTreant extends TestSetUp {
 				.getDecisionKnowledgeElement(sentences.get(0).getJiraIssueId());
 		TreantNode nodeStructure = treant.createNodeStructure(element, null, 4, 0);
 		assertEquals(TreantNode.class, nodeStructure.getClass());
-		assertEquals(0, nodeStructure.getChildren().size());
+		assertEquals(1, nodeStructure.getChildren().size());
 	}
 
 	public static final class AoSentenceTestDatabaseUpdater implements DatabaseUpdater {


### PR DESCRIPTION
ich habe versucht in meine Jira Projekt SlacCondec ein Issue vom Typ Entscheidung (decision) mit einem Issue vom Typ Entscheidungsproblem (issue) zu verlinken, indem ich per Rechtsklick 'link existing decision knowledge element' ausgewählt habe.
Das hat aber leider nicht funktioniert. Es kam ein Error 500: 'Creation of Link failed'.

Scheinbar funktioniert das nur noch, wenn man neue Kommentare anlegt. Aber man kann keine Jira-Issues  mehr untereinander verlinken über dieses Menu?

Pro- und Con-Argumente werden in der Tree-View auch nicht mehr angezeigt? 