### PR TITLE
CONDEC-776: Show trees in jstree viewer instead of only a list of knowledge elements in the rationale backlog and overview

### DIFF
--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/view/treeviewer/TreeViewer.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/view/treeviewer/TreeViewer.java
@@ -88,13 +88,22 @@ public class TreeViewer {
 		KnowledgeElement rootElement = filterSettings.getSelectedElement();
 
 		if (rootElement != null) {
+			// only one tree is shown
 			TreeViewerNode rootNode = getTreeViewerNodeWithChildren(rootElement);
 			nodes.add(rootNode);
 			return;
 		}
 
-		for (KnowledgeElement element : graph.vertexSet()) {
-			nodes.add(makeIdUnique(new TreeViewerNode(element)));
+		// many trees are shown in overview and rationale backlog
+		Set<KnowledgeElement> rootElements = graph.vertexSet();
+		filteringManager.getFilterSettings().setKnowledgeTypes(null);
+		filteringManager.getFilterSettings().setStatus(null);
+
+		for (KnowledgeElement element : rootElements) {
+			filteringManager.getFilterSettings().setSelectedElement(element);
+			filteringManager.getFilterSettings().setLinkDistance(2);
+			graph = filteringManager.getSubgraphMatchingFilterSettings();
+			nodes.add(getTreeViewerNodeWithChildren(element));
 		}
 	}
 

--- a/src/main/resources/js/condec.knowledge.page.js
+++ b/src/main/resources/js/condec.knowledge.page.js
@@ -73,7 +73,6 @@
 		var filterSettings = conDecFiltering.getFilterSettings("overview");
 		var knowledgeType = jQuery("select[name='knowledge-type-dropdown-overview']").val();
 		filterSettings["knowledgeTypes"] = [ knowledgeType ];
-		filterSettings["linkDistance"] = 0; // so that jstree tree viewer only shows a list of elements
 		filterSettings["isOnlyDecisionKnowledgeShown"] = false; // since this only applies on right side
 		conDecTreeViewer.buildTreeViewer(filterSettings, "#jstree", "#search-input-overview", "jstree");
 		if (nodeId === undefined) {

--- a/src/main/resources/js/condec.rationale.backlog.js
+++ b/src/main/resources/js/condec.rationale.backlog.js
@@ -33,8 +33,6 @@
 	function updateView(nodeId) {		
 		var filterSettings = conDecFiltering.getFilterSettings("rationale-backlog");
 		
-		// so that jstree tree viewer only shows a list of elements:
-		filterSettings["linkDistance"] = 0; 
 		filterSettings["isOnlyDecisionKnowledgeShown"] = false; // since this only applies on right side
 		
 		conDecTreeViewer.buildTreeViewer(filterSettings, "#rationale-backlog-tree", "#search-input-rationale-backlog", "rationale-backlog-tree");

--- a/src/main/resources/templates/filter/documentationDate.vm
+++ b/src/main/resources/templates/filter/documentationDate.vm
@@ -1,4 +1,4 @@
-<div title="A knowledge element matches this filter criterion if its creation and/or updating date is in the specified time frame.">
+<div style="display:inline" title="A knowledge element matches this filter criterion if its creation and/or updating date is in the specified time frame.">
 	<label for="start-date-picker-$viewIdentifier">$i18n.getText("condec.creation.date.start")</label> 
 	<input id="start-date-picker-$viewIdentifier" type="date" class="aui-date-picker"/>
 	<label for="end-date-picker-$viewIdentifier">$i18n.getText("condec.creation.date.end")</label> 


### PR DESCRIPTION
Currently, the jstree viewer on the left side of the rationale backlog and overview pages only shows a list of knowledge elements. However, it used to show a list of trees.

In this work item, the jstree viewer is changed to show a list of trees as it used to.

{issue}Should the jstree viewer show a list of trees or only a list of single knowledge elements in the rationale backlog and overview?{issue}
{decision}Show a list of trees in the jstree viewer on the left side of the rationale backlog and overview!{decision}
{pro}Knowledge elements can be moved via drag & drop from on tree to another.{pro}
{con}Long loading times (16 seconds for all issues on the overview page).{con}
{alternative}Show a list of single knowledge elements in the jstree viewer on the left side of the rationale backlog and overview!{alternative}
{con}Knowledge elements cannot be moved via drag & drop from on tree to another.{con}
{pro}Fast loading times (1.3 seconds for all issues on the overview page).{pro}