### PR TITLE
CONDEC-848: Delete knowledge elements and links after project deletion

### DIFF
--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/ComponentGetter.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/ComponentGetter.java
@@ -13,6 +13,8 @@ import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
 import com.atlassian.sal.api.user.UserManager;
 
 import de.uhd.ifi.se.decision.management.jira.config.AuthenticationManager;
+import de.uhd.ifi.se.decision.management.jira.extraction.GitClient;
+import de.uhd.ifi.se.decision.management.jira.model.KnowledgeGraph;
 import de.uhd.ifi.se.decision.management.jira.persistence.KnowledgePersistenceManager;
 
 /**
@@ -69,5 +71,11 @@ public class ComponentGetter {
 
 	public static String getUrlOfClassifierFolder() {
 		return getUrlOfResourcesFolder() + ":classifier-resources/";
+	}
+
+	public static void removeInstances(String projectKey) {
+		KnowledgeGraph.instances.remove(projectKey);
+		KnowledgePersistenceManager.instances.remove(projectKey);
+		GitClient.instances.remove(projectKey);
 	}
 }

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/ComponentGetter.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/ComponentGetter.java
@@ -73,6 +73,13 @@ public class ComponentGetter {
 		return getUrlOfResourcesFolder() + ":classifier-resources/";
 	}
 
+	/**
+	 * Removes the singleton objects of the {@link KnowledgeGraph}, the
+	 * {@link KnowledgePersistenceManager}, and the {@link GitClient} for a project.
+	 * 
+	 * @param projectKey
+	 *            of the Jira project.
+	 */
 	public static void removeInstances(String projectKey) {
 		KnowledgeGraph.instances.remove(projectKey);
 		KnowledgePersistenceManager.instances.remove(projectKey);

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/eventlistener/ConDecEventListener.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/eventlistener/ConDecEventListener.java
@@ -3,6 +3,8 @@ package de.uhd.ifi.se.decision.management.jira.eventlistener;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.inject.Inject;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.DisposableBean;
@@ -12,9 +14,11 @@ import org.springframework.stereotype.Component;
 
 import com.atlassian.event.api.EventListener;
 import com.atlassian.event.api.EventPublisher;
+import com.atlassian.jira.event.ProjectDeletedEvent;
 import com.atlassian.jira.event.issue.IssueEvent;
 import com.atlassian.jira.event.issue.link.IssueLinkCreatedEvent;
 import com.atlassian.jira.event.issue.link.IssueLinkDeletedEvent;
+import com.atlassian.plugin.spring.scanner.annotation.component.Scanned;
 import com.atlassian.plugin.spring.scanner.annotation.imports.JiraImport;
 
 import de.uhd.ifi.se.decision.management.jira.eventlistener.implementation.JiraIssueChangeListener;
@@ -33,6 +37,7 @@ import de.uhd.ifi.se.decision.management.jira.model.Link;
  * @see SummarizationEventListener
  * @see WebhookEventListener
  */
+@Scanned
 @Component
 public class ConDecEventListener implements InitializingBean, DisposableBean {
 
@@ -40,54 +45,48 @@ public class ConDecEventListener implements InitializingBean, DisposableBean {
 	private final EventPublisher eventPublisher;
 	private List<IssueEventListener> issueEventListeners;
 	private List<LinkEventListener> linkEventListeners;
+	private List<ProjectEventListener> projectEventListeners;
 
 	protected static final Logger LOGGER = LoggerFactory.getLogger(ConDecEventListener.class);
 
 	@Autowired
+	@Inject
 	public ConDecEventListener(EventPublisher eventPublisher) {
 		this.eventPublisher = eventPublisher;
 		LOGGER.info("ConDec event listener object was created.");
 		// init lists of listeners
 		issueEventListeners = new ArrayList<>();
 		linkEventListeners = new ArrayList<>();
+		projectEventListeners = new ArrayList<>();
 
 		// attach Jira issue event listeners
-		attach((IssueEventListener) new WebhookEventListener());
-		attach(new JiraIssueTextExtractionEventListener());
-		attach(new SummarizationEventListener());
-		attach(QualityCheckEventListenerSingleton.getInstance());
-		attach(new JiraIssueChangeListener());
+		issueEventListeners.add(new WebhookEventListener());
+		issueEventListeners.add(new JiraIssueTextExtractionEventListener());
+		issueEventListeners.add(new SummarizationEventListener());
+		issueEventListeners.add(QualityCheckEventListenerSingleton.getInstance());
+		issueEventListeners.add(new JiraIssueChangeListener());
 
 		// attach Jira issue link event listeners
-		attach((LinkEventListener) new WebhookEventListener());
-	}
+		linkEventListeners.add(new WebhookEventListener());
 
-	public void attach(IssueEventListener listener) {
-		this.issueEventListeners.add(listener);
-	}
-
-	public void attach(LinkEventListener listener) {
-		this.linkEventListeners.add(listener);
+		// attach Jira project deleted event listeners
+		projectEventListeners.add(new JiraIssueTextExtractionEventListener());
 	}
 
 	/**
 	 * Called when the plugin has been enabled.
-	 *
-	 * @throws Exception
 	 */
 	@Override
-	public void afterPropertiesSet() throws Exception {
+	public void afterPropertiesSet() {
 		eventPublisher.register(this);
 		LOGGER.info("ConDec event listener was registered in Jira.");
 	}
 
 	/**
 	 * Called when the plugin is being disabled or removed.
-	 *
-	 * @throws Exception
 	 */
 	@Override
-	public void destroy() throws Exception {
+	public void destroy() {
 		eventPublisher.unregister(this);
 		LOGGER.info("ConDec event listener was removed from Jira.");
 	}
@@ -117,5 +116,14 @@ public class ConDecEventListener implements InitializingBean, DisposableBean {
 		KnowledgeGraph.getOrCreate(element.getProject()).removeEdge(link);
 		linkEventListeners.forEach(linkEventListener -> linkEventListener.onLinkEvent(element));
 		LOGGER.info("ConDec event listener on link deleted issue event was triggered.");
+	}
+
+	@EventListener
+	public void onProjectDeletedEvent(ProjectDeletedEvent projectDeletedEvent) {
+		if (projectDeletedEvent == null) {
+			return;
+		}
+		this.projectEventListeners
+				.forEach(projectEventListener -> projectEventListener.onProjectDeletion(projectDeletedEvent));
 	}
 }

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/eventlistener/ConDecEventListener.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/eventlistener/ConDecEventListener.java
@@ -21,6 +21,7 @@ import com.atlassian.jira.event.issue.link.IssueLinkDeletedEvent;
 import com.atlassian.plugin.spring.scanner.annotation.component.Scanned;
 import com.atlassian.plugin.spring.scanner.annotation.imports.JiraImport;
 
+import de.uhd.ifi.se.decision.management.jira.ComponentGetter;
 import de.uhd.ifi.se.decision.management.jira.eventlistener.implementation.JiraIssueChangeListener;
 import de.uhd.ifi.se.decision.management.jira.eventlistener.implementation.JiraIssueTextExtractionEventListener;
 import de.uhd.ifi.se.decision.management.jira.eventlistener.implementation.QualityCheckEventListenerSingleton;
@@ -125,5 +126,6 @@ public class ConDecEventListener implements InitializingBean, DisposableBean {
 		}
 		this.projectEventListeners
 				.forEach(projectEventListener -> projectEventListener.onProjectDeletion(projectDeletedEvent));
+		ComponentGetter.removeInstances(projectDeletedEvent.getProject().getKey());
 	}
 }

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/eventlistener/ConDecEventListener.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/eventlistener/ConDecEventListener.java
@@ -3,8 +3,6 @@ package de.uhd.ifi.se.decision.management.jira.eventlistener;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.inject.Inject;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.DisposableBean;
@@ -18,7 +16,6 @@ import com.atlassian.jira.event.ProjectDeletedEvent;
 import com.atlassian.jira.event.issue.IssueEvent;
 import com.atlassian.jira.event.issue.link.IssueLinkCreatedEvent;
 import com.atlassian.jira.event.issue.link.IssueLinkDeletedEvent;
-import com.atlassian.plugin.spring.scanner.annotation.component.Scanned;
 import com.atlassian.plugin.spring.scanner.annotation.imports.JiraImport;
 
 import de.uhd.ifi.se.decision.management.jira.ComponentGetter;
@@ -38,7 +35,6 @@ import de.uhd.ifi.se.decision.management.jira.model.Link;
  * @see SummarizationEventListener
  * @see WebhookEventListener
  */
-@Scanned
 @Component
 public class ConDecEventListener implements InitializingBean, DisposableBean {
 
@@ -51,7 +47,6 @@ public class ConDecEventListener implements InitializingBean, DisposableBean {
 	protected static final Logger LOGGER = LoggerFactory.getLogger(ConDecEventListener.class);
 
 	@Autowired
-	@Inject
 	public ConDecEventListener(EventPublisher eventPublisher) {
 		this.eventPublisher = eventPublisher;
 		LOGGER.info("ConDec event listener object was created.");

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/eventlistener/LinkEventListener.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/eventlistener/LinkEventListener.java
@@ -3,8 +3,9 @@ package de.uhd.ifi.se.decision.management.jira.eventlistener;
 import de.uhd.ifi.se.decision.management.jira.model.KnowledgeElement;
 
 public interface LinkEventListener {
+
 	/**
-	 * Listener method.
+	 * Event listener method.
 	 *
 	 * @param element
 	 */

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/eventlistener/ProjectEventListener.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/eventlistener/ProjectEventListener.java
@@ -1,0 +1,14 @@
+package de.uhd.ifi.se.decision.management.jira.eventlistener;
+
+import com.atlassian.jira.event.ProjectDeletedEvent;
+
+public interface ProjectEventListener {
+
+	/**
+	 * Event listener method.
+	 *
+	 * @param projectDeleted
+	 *            that triggered the listener
+	 */
+	void onProjectDeletion(ProjectDeletedEvent projectDeletedEvent);
+}

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/eventlistener/implementation/JiraIssueTextExtractionEventListener.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/eventlistener/implementation/JiraIssueTextExtractionEventListener.java
@@ -10,7 +10,6 @@ import com.atlassian.jira.event.type.EventType;
 import com.atlassian.jira.issue.MutableIssue;
 import com.atlassian.jira.issue.comments.MutableComment;
 
-import de.uhd.ifi.se.decision.management.jira.ComponentGetter;
 import de.uhd.ifi.se.decision.management.jira.classification.implementation.ClassificationManagerForJiraIssueComments;
 import de.uhd.ifi.se.decision.management.jira.eventlistener.IssueEventListener;
 import de.uhd.ifi.se.decision.management.jira.eventlistener.ProjectEventListener;
@@ -168,8 +167,8 @@ public class JiraIssueTextExtractionEventListener implements IssueEventListener,
 		projectKey = projectDeletedEvent.getProject().getKey();
 		JiraIssueTextPersistenceManager persistenceManager = KnowledgePersistenceManager.getOrCreate(projectKey)
 				.getJiraIssueTextManager();
-		persistenceManager.deleteInvalidElements(projectDeletedEvent.getUser());
+		persistenceManager.getKnowledgeElements()
+				.forEach(element -> persistenceManager.deleteKnowledgeElement(element, projectDeletedEvent.getUser()));
 		GenericLinkManager.deleteInvalidLinks();
-		ComponentGetter.removeInstances(projectKey);
 	}
 }

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/eventlistener/implementation/JiraIssueTextExtractionEventListener.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/eventlistener/implementation/JiraIssueTextExtractionEventListener.java
@@ -167,8 +167,7 @@ public class JiraIssueTextExtractionEventListener implements IssueEventListener,
 		projectKey = projectDeletedEvent.getProject().getKey();
 		JiraIssueTextPersistenceManager persistenceManager = KnowledgePersistenceManager.getOrCreate(projectKey)
 				.getJiraIssueTextManager();
-		persistenceManager.getKnowledgeElements()
-				.forEach(element -> persistenceManager.deleteKnowledgeElement(element, projectDeletedEvent.getUser()));
+		persistenceManager.deleteElementsOfProject();
 		GenericLinkManager.deleteInvalidLinks();
 	}
 }

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/persistence/singlelocations/JiraIssueTextPersistenceManager.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/persistence/singlelocations/JiraIssueTextPersistenceManager.java
@@ -124,6 +124,25 @@ public class JiraIssueTextPersistenceManager extends AbstractPersistenceManagerF
 		return deleteElementsInDescription(jiraIssue);
 	}
 
+	/**
+	 * Deletes all decision knowledge elements and their links documented in the
+	 * description and all comments of a Jira project. Does not delete the text or
+	 * change the description itself.
+	 *
+	 * @return true if deletion was successfull.
+	 */
+	public boolean deleteElementsOfProject() {
+		boolean isDeleted = false;
+		PartOfJiraIssueTextInDatabase[] databaseEntries = ACTIVE_OBJECTS.find(PartOfJiraIssueTextInDatabase.class,
+				Query.select().where("PROJECT_KEY = ?", projectKey));
+		for (PartOfJiraIssueTextInDatabase databaseEntry : databaseEntries) {
+			KnowledgeGraph.getOrCreate(projectKey).removeVertex(new PartOfJiraIssueText(databaseEntry));
+			GenericLinkManager.deleteLinksForElement(databaseEntry.getId(), DocumentationLocation.JIRAISSUETEXT);
+			isDeleted = PartOfJiraIssueTextInDatabase.deleteElement(databaseEntry);
+		}
+		return isDeleted;
+	}
+
 	private boolean deletePartsOfText(long jiraIssueId, long commentId) {
 		boolean isDeleted = false;
 		PartOfJiraIssueTextInDatabase[] databaseEntries = ACTIVE_OBJECTS.find(PartOfJiraIssueTextInDatabase.class,

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/rest/ConfigRest.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/rest/ConfigRest.java
@@ -28,6 +28,7 @@ import com.atlassian.jira.user.ApplicationUser;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 
+import de.uhd.ifi.se.decision.management.jira.ComponentGetter;
 import de.uhd.ifi.se.decision.management.jira.classification.OnlineTrainer;
 import de.uhd.ifi.se.decision.management.jira.classification.implementation.ClassificationManagerForJiraIssueComments;
 import de.uhd.ifi.se.decision.management.jira.classification.implementation.OnlineFileTrainerImpl;
@@ -42,7 +43,6 @@ import de.uhd.ifi.se.decision.management.jira.extraction.versioncontrol.GitRepos
 import de.uhd.ifi.se.decision.management.jira.filtering.JiraQueryHandler;
 import de.uhd.ifi.se.decision.management.jira.model.DecisionKnowledgeProject;
 import de.uhd.ifi.se.decision.management.jira.model.KnowledgeElement;
-import de.uhd.ifi.se.decision.management.jira.model.KnowledgeGraph;
 import de.uhd.ifi.se.decision.management.jira.model.KnowledgeType;
 import de.uhd.ifi.se.decision.management.jira.model.LinkType;
 import de.uhd.ifi.se.decision.management.jira.persistence.ConfigPersistenceManager;
@@ -73,7 +73,7 @@ public class ConfigRest {
 		}
 		ConfigPersistenceManager.setActivated(projectKey, isActivated);
 		setDefaultKnowledgeTypesEnabled(projectKey, isActivated);
-		resetKnowledgeGraph(projectKey);
+		ComponentGetter.removeInstances(projectKey);
 		return Response.ok().build();
 	}
 
@@ -82,12 +82,6 @@ public class ConfigRest {
 		for (KnowledgeType knowledgeType : defaultKnowledgeTypes) {
 			ConfigPersistenceManager.setKnowledgeTypeEnabled(projectKey, knowledgeType.toString(), isActivated);
 		}
-	}
-
-	private static void resetKnowledgeGraph(String projectKey) {
-		KnowledgeGraph.instances.remove(projectKey);
-		KnowledgePersistenceManager.instances.remove(projectKey);
-		GitClient.instances.remove(projectKey);
 	}
 
 	@Path("/isActivated")
@@ -955,8 +949,8 @@ public class ConfigRest {
 	@Path("/setRecommendationInput")
 	@POST
 	public Response setRecommendationInput(@Context HttpServletRequest request,
-			@QueryParam("projectKey") String projectKey,
-			@QueryParam("recommendationInput") String recommendationInput, @QueryParam("isActivated") boolean isActivated) {
+			@QueryParam("projectKey") String projectKey, @QueryParam("recommendationInput") String recommendationInput,
+			@QueryParam("isActivated") boolean isActivated) {
 		Response response = RestParameterChecker.checkIfDataIsValid(request, projectKey);
 		if (response.getStatus() != 200) {
 			return response;

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/eventlistener/jiraissuetextextractioneventlistener/TestEventProjectDeleted.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/eventlistener/jiraissuetextextractioneventlistener/TestEventProjectDeleted.java
@@ -1,0 +1,54 @@
+package de.uhd.ifi.se.decision.management.jira.eventlistener.jiraissuetextextractioneventlistener;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.atlassian.jira.component.ComponentAccessor;
+import com.atlassian.jira.event.ProjectDeletedEvent;
+import com.atlassian.jira.issue.comments.Comment;
+
+import de.uhd.ifi.se.decision.management.jira.model.KnowledgeElement;
+import de.uhd.ifi.se.decision.management.jira.testdata.JiraProjects;
+import net.java.ao.test.jdbc.NonTransactional;
+
+public class TestEventProjectDeleted extends TestSetUpEventListener {
+
+	private boolean testProjectDeletedEvent(String commentBody) {
+		Comment comment = createComment(commentBody);
+		ComponentAccessor.getCommentManager().delete(comment);
+		ProjectDeletedEvent projectDeletedEvent = new ProjectDeletedEvent(user, JiraProjects.getTestProject());
+		listener.onProjectDeletedEvent(projectDeletedEvent);
+
+		boolean isCommentDeleted = !isCommentExistent(commentBody);
+
+		KnowledgeElement element = getFirstElementInComment(comment);
+		boolean isElementDeletedInDatabase = (element == null);
+
+		return isCommentDeleted && isElementDeletedInDatabase;
+	}
+
+	@Test
+	@NonTransactional
+	public void testNoCommentContained() {
+		assertTrue(testProjectDeletedEvent(""));
+	}
+
+	@Test
+	@NonTransactional
+	public void testRationaleTag() {
+		assertTrue(testProjectDeletedEvent("{issue}This is a very severe issue.{issue}"));
+	}
+
+	@Test
+	@NonTransactional
+	public void testExcludedTag() {
+		assertTrue(testProjectDeletedEvent("{code}public static class{code}"));
+	}
+
+	@Test
+	@NonTransactional
+	public void testRationaleIcon() {
+		assertTrue(testProjectDeletedEvent("(!)This is a very severe issue."));
+	}
+}

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/eventlistener/jiraissuetextextractioneventlistener/TestEventProjectDeleted.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/eventlistener/jiraissuetextextractioneventlistener/TestEventProjectDeleted.java
@@ -4,51 +4,27 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
-import com.atlassian.jira.component.ComponentAccessor;
 import com.atlassian.jira.event.ProjectDeletedEvent;
-import com.atlassian.jira.issue.comments.Comment;
 
-import de.uhd.ifi.se.decision.management.jira.model.KnowledgeElement;
+import de.uhd.ifi.se.decision.management.jira.persistence.KnowledgePersistenceManager;
+import de.uhd.ifi.se.decision.management.jira.persistence.singlelocations.JiraIssueTextPersistenceManager;
+import de.uhd.ifi.se.decision.management.jira.testdata.JiraIssues;
 import de.uhd.ifi.se.decision.management.jira.testdata.JiraProjects;
 import net.java.ao.test.jdbc.NonTransactional;
 
 public class TestEventProjectDeleted extends TestSetUpEventListener {
 
-	private boolean testProjectDeletedEvent(String commentBody) {
-		Comment comment = createComment(commentBody);
-		ComponentAccessor.getCommentManager().delete(comment);
+	@Test
+	@NonTransactional
+	public void testDeleteProject() {
+		JiraIssues.addElementToDataBase();
+		JiraIssueTextPersistenceManager persistenceManager = KnowledgePersistenceManager.getOrCreate("TEST")
+				.getJiraIssueTextManager();
+		assertTrue(persistenceManager.getKnowledgeElements().size() > 0);
+
 		ProjectDeletedEvent projectDeletedEvent = new ProjectDeletedEvent(user, JiraProjects.getTestProject());
 		listener.onProjectDeletedEvent(projectDeletedEvent);
 
-		boolean isCommentDeleted = !isCommentExistent(commentBody);
-
-		KnowledgeElement element = getFirstElementInComment(comment);
-		boolean isElementDeletedInDatabase = (element == null);
-
-		return isCommentDeleted && isElementDeletedInDatabase;
-	}
-
-	@Test
-	@NonTransactional
-	public void testNoCommentContained() {
-		assertTrue(testProjectDeletedEvent(""));
-	}
-
-	@Test
-	@NonTransactional
-	public void testRationaleTag() {
-		assertTrue(testProjectDeletedEvent("{issue}This is a very severe issue.{issue}"));
-	}
-
-	@Test
-	@NonTransactional
-	public void testExcludedTag() {
-		assertTrue(testProjectDeletedEvent("{code}public static class{code}"));
-	}
-
-	@Test
-	@NonTransactional
-	public void testRationaleIcon() {
-		assertTrue(testProjectDeletedEvent("(!)This is a very severe issue."));
+		assertTrue(persistenceManager.getKnowledgeElements().size() == 0);
 	}
 }

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/eventlistener/jiraissuetextextractioneventlistener/TestSetUpEventListener.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/eventlistener/jiraissuetextextractioneventlistener/TestSetUpEventListener.java
@@ -25,7 +25,7 @@ import de.uhd.ifi.se.decision.management.jira.testdata.JiraUsers;
 public abstract class TestSetUpEventListener extends TestSetUp {
 
 	protected MutableIssue jiraIssue;
-	private ApplicationUser user;
+	protected ApplicationUser user;
 
 	protected ConDecEventListener listener;
 


### PR DESCRIPTION
Add ProjectEventListener interface and implement onProjectDeletion listener in JiraIssueTextPersistenceManager

[issue] How can we clean up after the deletion of a Jira project? [/issue]
[decision] Delete all knowledge elements and links from Jira issue description and comments after project deletion in database! Remove all singleton objects for the project! [/decision]