### PR TITLE
CONDEC-938: Improve the unified just-in-time prompt

### DIFF
--- a/src/main/resources/i18n/condec.properties
+++ b/src/main/resources/i18n/condec.properties
@@ -89,6 +89,8 @@ condec.create.label=Summary of new element
 condec.depth.of.tree.label=Depth of Tree
 condec.link.distance.label=Maximum Link Distance
 condec.minimum.decision.coverage.label=Minimum Decision Coverage
+# Text classification view
+condec.label.text.classification=Text Classification
 # Decision Compare View
 condec.label.compare=Comparison
 condec.datepicker.start=Start Time
@@ -160,3 +162,4 @@ condec.decision.guidance.accept=Accept
 condec.duplicate=Duplicate
 condec.classification.nonvalidatedelement=Element
 condec.classification.classifiedknowledgetype=Classified knowledge type
+condec.button.continue=Continue

--- a/src/main/resources/i18n/condec_de_DE.properties
+++ b/src/main/resources/i18n/condec_de_DE.properties
@@ -83,6 +83,8 @@ condec.filter.label=Enth\u00e4lt Text
 condec.create.label=Zusammenfassung eines neuen Elements
 condec.depth.of.tree.label=Baumtiefe
 condec.link.distance.label=Linkdistanz
+# Text classification view
+condec.label.text.classification=Textklassifizierung
 # Decision Compare View
 condec.label.compare=Gegen\u00fcberstellung
 condec.datepicker.start=Startzeitpunkt
@@ -124,3 +126,4 @@ condec.decision.guidance.accept=Akzeptieren
 condec.duplicate=Duplikat
 condec.classification.nonvalidatedelement=Element
 condec.classification.classifiedknowledgetype=Wissenstyp
+condec.button.continue=Weiter

--- a/src/main/resources/js/classification/condec.text.classification.api.js
+++ b/src/main/resources/js/classification/condec.text.classification.api.js
@@ -105,10 +105,11 @@
 	}
 
 	ConDecTextClassificationAPI.prototype.validateAllElements = function (projectKey, issueKey) {
-		return generalApi.postJSON(`${this.restPrefix}
+		return generalApi.postJSONReturnPromise(`${this.restPrefix}
 		/validateAllElements.json
 		?projectKey=${projectKey}
-		&issueKey=${issueKey}`
+		&issueKey=${issueKey}`,
+			null
 		);
 	}
 

--- a/src/main/resources/js/classification/condec.text.classification.js
+++ b/src/main/resources/js/classification/condec.text.classification.js
@@ -43,7 +43,7 @@
 			this.validateAllButton.style.display = "inline";
 			this.validateAllButton.onclick = () => {
 				conDecTextClassificationAPI.validateAllElements(this.projectKey, conDecAPI.getIssueKey())
-				conDecObservable.notify()
+					.then(() => conDecObservable.notify());
 			}
 		}
 		AJS.tabs.setup();

--- a/src/main/resources/js/nudging/condec.prompts.js
+++ b/src/main/resources/js/nudging/condec.prompts.js
@@ -132,7 +132,8 @@
 					});
 					document.getElementById("non-validated-table-body").innerHTML = tableContents;
 					validateAllButton.onclick = function () {
-						conDecTextClassificationAPI.validateAllElements(conDecAPI.projectKey, issueKey);
+						conDecTextClassificationAPI.validateAllElements(conDecAPI.projectKey, issueKey)
+							.then(() => conDecObservable.notify());
 					};
 				}
 				document.getElementById("non-validated-spinner").style.display = "none";

--- a/src/main/resources/js/nudging/condec.prompts.js
+++ b/src/main/resources/js/nudging/condec.prompts.js
@@ -44,7 +44,7 @@
 							document.getElementById("definition-of-done-prompt").style.display = "block";
 							document.getElementById("go-to-quality-check-tab").onclick = () => {
 								AJS.tabs.change(jQuery('a[href="#quality-check-tab"]'));
-								window.open("#", "blank");
+								window.open("#quality-check-tab", "blank");
 							}
 
 						}
@@ -54,7 +54,7 @@
 
 							document.getElementById("go-to-link-recomendation-tab").onclick = () => {
 								AJS.tabs.change(jQuery('a[href="#link-recommendation-tab"]'));
-								window.open("#", "blank");
+								window.open("#link-recommendation-tab", "blank");
 							}
 						}
 						if (isTextClassificationActivated) {
@@ -62,9 +62,10 @@
 							document.getElementById("non-validated-elements-prompt").style.display = "block";
 							document.getElementById("go-to-classification-tab").onclick =
 								() => {
-								AJS.tabs.change(jQuery('a[href="#text-classification-tab"]'));
-								window.open("#", "blank");
-							}
+									AJS.tabs.change(jQuery('a[href="#text-classification-tab"]'));
+									window.open("#text-classification-tab", "blank");
+
+								}
 						}
 						if (isDecisionGuidanceActivated) {
 							conDecPrompt.promptDecisionGuidance();
@@ -72,7 +73,7 @@
 							document.getElementById("go-to-decision-guidance-tab").onclick =
 								() => {
 									AJS.tabs.change(jQuery('a[href="#decision-guidance-tab"]'));
-									window.open("#", "blank");
+									window.open("#decision-guidance-tab", "blank");
 								}
 						}
 					});

--- a/src/main/resources/js/nudging/condec.prompts.js
+++ b/src/main/resources/js/nudging/condec.prompts.js
@@ -1,19 +1,16 @@
-(function(global) {
+(function (global) {
 
-	const ConDecPrompt = function() {
+	const ConDecPrompt = function () {
 		this.restPrefix = AJS.contextPath() + "/rest/condec/latest/nudging";
-		jQuery(document).ajaxComplete(function(event, request, settings) {
+		jQuery(document).ajaxComplete(function (event, request, settings) {
 			if (settings.url.includes("WorkflowUIDispatcher.jspa")) {
 				const issueKey = conDecAPI.getIssueKey();
 				// Create unified prompt
 				document.getElementById("unified-prompt-header").innerHTML = "Recommendations for " + issueKey + "...";
 
 				const unifiedPromptElement = document.getElementById("unified-prompt");
-				document.getElementById("warning-dialog-fix-elements").onclick = function() {
-					AJS.dialog2(unifiedPromptElement).hide();
-				}// TODO change this so it actually stops the event from continuing
 
-				document.getElementById("warning-dialog-continue").onclick = function() {
+				document.getElementById("warning-dialog-continue").onclick = function () {
 					AJS.dialog2(unifiedPromptElement).hide();
 				}
 
@@ -30,7 +27,7 @@
 				])
 					.then(([isDoDCheckActivated, isLinkRecommendationActivated, isTextClassificationActivated, isDecisionGuidanceActivated]) => {
 						/**
-						 * @issue The page is reloaded and the ambient feedback is removed again on the 
+						 * @issue The page is reloaded and the ambient feedback is removed again on the
 						 * link recommendation menu item. How can we prevent this?
 						 * @alternative Use jQuery(document).ready to wait for the page to be loaded.
 						 * @con Does not work, the link recommendation menu item coloring is removed.
@@ -62,7 +59,7 @@
 		});
 	};
 
-	ConDecPrompt.prototype.promptLinkSuggestion = function() {
+	ConDecPrompt.prototype.promptLinkSuggestion = function () {
 		const issueId = JIRA.Issue.getIssueId();
 		const projectKey = conDecAPI.projectKey;
 		if (issueId === null || issueId === undefined) {
@@ -70,7 +67,7 @@
 		}
 
 		Promise.all([conDecLinkRecommendationAPI.getDuplicateKnowledgeElement(projectKey, issueId, "i"),
-		conDecLinkRecommendationAPI.getRelatedKnowledgeElements(projectKey, issueId, "i")]) // TODO: could add list of the elements here
+			conDecLinkRecommendationAPI.getRelatedKnowledgeElements(projectKey, issueId, "i")]) // TODO: could add list of the elements here
 			.then((recommendations) => {
 				let numDuplicates = conDecRecommendation.getNumberOfNonDiscardedRecommendations(recommendations[0]);
 				let numLinkRecommendations = conDecRecommendation.getNumberOfNonDiscardedRecommendations(recommendations[1]);
@@ -82,7 +79,7 @@
 			});
 	}
 
-	ConDecPrompt.prototype.promptDefinitionOfDoneChecking = function() {
+	ConDecPrompt.prototype.promptDefinitionOfDoneChecking = function () {
 		const projectKey = conDecAPI.getProjectKey();
 		if (projectKey === null || projectKey === undefined) {
 			return;
@@ -108,7 +105,7 @@
 		document.getElementById("definition-of-done-checking-prompt-jira-issue-key").innerHTML = conDecAPI.getIssueKey();
 	}
 
-	ConDecPrompt.prototype.promptNonValidatedElements = function() {
+	ConDecPrompt.prototype.promptNonValidatedElements = function () {
 		const issueKey = conDecAPI.getIssueKey();
 		if (issueKey === null || issueKey === undefined) {
 			return;
@@ -116,31 +113,31 @@
 
 		conDecTextClassificationAPI.getNonValidatedElements(conDecAPI.projectKey, issueKey)
 			.then(response => {
-				if (response["nonValidatedElements"].length === 0) {
-					return;
-				}
 				const nonValidatedElements = response["nonValidatedElements"]
+				document.getElementById("num-non-validated-elements").innerHTML = nonValidatedElements.length;
 
-				document.getElementById("num-non-validated-elements").innerHTML = response["nonValidatedElements"].length
+				if (nonValidatedElements.length === 0) {
+					document.getElementById("non-validated-table-body").innerHTML = "<i>All elements have been validated!</i>";
+					document.getElementById("non-validated-elements-validate-button").style.display = "none";
+				} else {
+					let tableContents = "";
+					nonValidatedElements.forEach(recommendation => {
+						let tableRow = "<tr>";
+						tableRow += "<td> " + recommendation.summary + "</td>";
+						tableRow += "<td>" + recommendation.type + "</td>";
+						tableRow += "</tr>";
+						tableContents += tableRow;
 
-
-				let tableContents = "";
-				nonValidatedElements.forEach(recommendation => {
-					let tableRow = "<tr>";
-					tableRow += "<td> " + recommendation.summary + "</td>";
-					tableRow += "<td>" + recommendation.type + "</td>";
-					tableRow += "</tr>";
-					tableContents += tableRow;
-
-				});
-				document.getElementById("non-validated-table-body").innerHTML = tableContents;
-				document.getElementById("non-validated-elements-validate-button").onclick = function() {
-					conDecTextClassificationAPI.validateAllElements(conDecAPI.projectKey, issueKey);
-				};
+					});
+					document.getElementById("non-validated-table-body").innerHTML = tableContents;
+					document.getElementById("non-validated-elements-validate-button").onclick = function () {
+						conDecTextClassificationAPI.validateAllElements(conDecAPI.projectKey, issueKey);
+					};
+				}
 			})
 	};
 
-	ConDecPrompt.prototype.promptDecisionGuidance = function() {
+	ConDecPrompt.prototype.promptDecisionGuidance = function () {
 		const issueKey = conDecAPI.getIssueKey();
 		if (issueKey === null || issueKey === undefined) {
 			return;
@@ -172,6 +169,5 @@
 				}
 			});
 	};
-
 	global.conDecPrompt = new ConDecPrompt();
 })(window);

--- a/src/main/resources/js/nudging/condec.prompts.js
+++ b/src/main/resources/js/nudging/condec.prompts.js
@@ -42,18 +42,38 @@
 						if (isDoDCheckActivated) {
 							conDecPrompt.promptDefinitionOfDoneChecking();
 							document.getElementById("definition-of-done-prompt").style.display = "block";
+							document.getElementById("go-to-quality-check-tab").onclick = () => {
+								AJS.tabs.change(jQuery('a[href="#quality-check-tab"]'));
+								window.open("#", "blank");
+							}
+
 						}
 						if (isLinkRecommendationActivated) {
 							conDecPrompt.promptLinkSuggestion();
 							document.getElementById("link-recommendation-prompt").style.display = "block";
+
+							document.getElementById("go-to-link-recomendation-tab").onclick = () => {
+								AJS.tabs.change(jQuery('a[href="#link-recommendation-tab"]'));
+								window.open("#", "blank");
+							}
 						}
 						if (isTextClassificationActivated) {
 							conDecPrompt.promptNonValidatedElements();
 							document.getElementById("non-validated-elements-prompt").style.display = "block";
+							document.getElementById("go-to-classification-tab").onclick =
+								() => {
+								AJS.tabs.change(jQuery('a[href="#text-classification-tab"]'));
+								window.open("#", "blank");
+							}
 						}
 						if (isDecisionGuidanceActivated) {
 							conDecPrompt.promptDecisionGuidance();
 							document.getElementById("decision-guidance-prompt").style.display = "block";
+							document.getElementById("go-to-decision-guidance-tab").onclick =
+								() => {
+									AJS.tabs.change(jQuery('a[href="#decision-guidance-tab"]'));
+									window.open("#", "blank");
+								}
 						}
 					});
 			}
@@ -110,7 +130,6 @@
 			return;
 		}
 		const validateAllButton = document.getElementById("non-validated-elements-validate-button");
-		const goToClassificationTabButton = document.getElementById("non-validated-elements-go-to-classification-tab");
 		conDecTextClassificationAPI.getNonValidatedElements(conDecAPI.projectKey, issueKey)
 			.then(response => {
 				const nonValidatedElements = response["nonValidatedElements"]

--- a/src/main/resources/js/nudging/condec.prompts.js
+++ b/src/main/resources/js/nudging/condec.prompts.js
@@ -77,6 +77,7 @@
 					document.getElementById("link-recommendation-prompt-num-duplicate-recommendations").innerText = numDuplicates;
 					conDecNudgingAPI.decideAmbientFeedbackForTab(numDuplicates + numLinkRecommendations, "menu-item-link-recommendation");
 				}
+				document.getElementById("link-recommendation-spinner").style.display = "none";
 			});
 	}
 
@@ -90,18 +91,15 @@
 		if (issueKey === null || issueKey === undefined) {
 			return;
 		}
-
 		conDecAPI.getFilterSettings(projectKey, "", settings => {
-
 			document.getElementById("condec-prompt-minimum-coverage").innerHTML = settings.minimumDecisionCoverage;
 			document.getElementById("condec-prompt-link-distance").innerHTML = settings.linkDistance;
 		});
-
 		conDecDoDCheckingAPI.getCoverageOfJiraIssue(projectKey, issueKey, (coverage) => {
 			document.getElementById("condec-prompt-issue-coverage").innerHTML = coverage["Issue"];
 			document.getElementById("condec-prompt-decision-coverage").innerHTML = coverage["Decision"];
+			document.getElementById("dod-spinner").style.display = "none";
 		});
-
 
 		document.getElementById("definition-of-done-checking-prompt-jira-issue-key").innerHTML = conDecAPI.getIssueKey();
 	}
@@ -137,6 +135,7 @@
 						conDecTextClassificationAPI.validateAllElements(conDecAPI.projectKey, issueKey);
 					};
 				}
+				document.getElementById("non-validated-spinner").style.display = "none";
 			})
 	};
 
@@ -149,28 +148,27 @@
 		const filterSettings = {
 			"projectKey": projectKey,
 			"selectedElement": issueKey
-		}
+		};
 		conDecDecisionGuidanceAPI.getRecommendations(filterSettings)
-			.then((recommendationsMap, error) => {
-				if (error === null || error === undefined) {
-					document.getElementById("num-decision-problems").innerHTML = Object.keys(recommendationsMap).length;
-					var totalNumberOfRecommendations = 0;
-					Object.keys(recommendationsMap).forEach((id) => {
-						conDecAPI.getDecisionKnowledgeElement(id, 's', (decisionProblem) => {
-							let numberOfRecommendations = recommendationsMap[id].length;
-							let tableRow = "<tr>";
-							tableRow += "<td>" + decisionProblem.summary + "</td>";
-							tableRow += "<td>" + numberOfRecommendations + "</td>";
-							tableRow += "</tr>";
-							document.getElementById("decision-problems-table-body").innerHTML += tableRow;
-							totalNumberOfRecommendations += numberOfRecommendations;
-							conDecNudgingAPI.decideAmbientFeedbackForTab(totalNumberOfRecommendations, "menu-item-decision-guidance");
-						});
+			.then((recommendationsMap) => {
+				document.getElementById("num-decision-problems").innerHTML = Object.keys(recommendationsMap).length;
+				var totalNumberOfRecommendations = 0;
+				Object.keys(recommendationsMap).forEach((id) => {
+					conDecAPI.getDecisionKnowledgeElement(id, 's', (decisionProblem) => {
+						let numberOfRecommendations = recommendationsMap[id].length;
+						let tableRow = "<tr>";
+						tableRow += "<td>" + decisionProblem.summary + "</td>";
+						tableRow += "<td>" + numberOfRecommendations + "</td>";
+						tableRow += "</tr>";
+						document.getElementById("decision-problems-table-body").innerHTML += tableRow;
+						totalNumberOfRecommendations += numberOfRecommendations;
+
+						document.getElementById("decision-guidance-spinner").style.display = "none";
+						conDecNudgingAPI.decideAmbientFeedbackForTab(totalNumberOfRecommendations, "menu-item-decision-guidance");
 					});
-				} else {
-					console.log("Error in making decision guidance prompt table was: ", error);
-				}
-			});
+				});
+			})
+			.catch(error => console.log("Error in making decision guidance prompt table was: ", error));
 	};
 	global.conDecPrompt = new ConDecPrompt();
 })(window);

--- a/src/main/resources/js/nudging/condec.prompts.js
+++ b/src/main/resources/js/nudging/condec.prompts.js
@@ -4,6 +4,7 @@
 		this.restPrefix = AJS.contextPath() + "/rest/condec/latest/nudging";
 		jQuery(document).ajaxComplete(function (event, request, settings) {
 			if (settings.url.includes("WorkflowUIDispatcher.jspa")) {
+				AJS.tabs.setup();
 				const issueKey = conDecAPI.getIssueKey();
 				// Create unified prompt
 				document.getElementById("unified-prompt-header").innerHTML = "Recommendations for " + issueKey + "...";
@@ -110,15 +111,17 @@
 		if (issueKey === null || issueKey === undefined) {
 			return;
 		}
-
+		const validateAllButton = document.getElementById("non-validated-elements-validate-button");
+		const goToClassificationTabButton = document.getElementById("non-validated-elements-go-to-classification-tab");
 		conDecTextClassificationAPI.getNonValidatedElements(conDecAPI.projectKey, issueKey)
 			.then(response => {
 				const nonValidatedElements = response["nonValidatedElements"]
 				document.getElementById("num-non-validated-elements").innerHTML = nonValidatedElements.length;
+				conDecNudgingAPI.decideAmbientFeedbackForTab(nonValidatedElements.length, "text-classification-tab");
 
 				if (nonValidatedElements.length === 0) {
 					document.getElementById("non-validated-table-body").innerHTML = "<i>All elements have been validated!</i>";
-					document.getElementById("non-validated-elements-validate-button").style.display = "none";
+					validateAllButton.style.display = "none";
 				} else {
 					let tableContents = "";
 					nonValidatedElements.forEach(recommendation => {
@@ -130,7 +133,7 @@
 
 					});
 					document.getElementById("non-validated-table-body").innerHTML = tableContents;
-					document.getElementById("non-validated-elements-validate-button").onclick = function () {
+					validateAllButton.onclick = function () {
 						conDecTextClassificationAPI.validateAllElements(conDecAPI.projectKey, issueKey);
 					};
 				}

--- a/src/main/resources/templates/jiraIssueModule.vm
+++ b/src/main/resources/templates/jiraIssueModule.vm
@@ -40,7 +40,7 @@ $webResourceManager.requireResource("de.uhd.ifi.se.decision.management.jira:deci
             <a href="#quality-check-tab">$i18n.getText('condec.label.quality')</a>
         </li>
         <li class="menu-item" id="menu-item-text-classification">
-            <a href="#text-classification-tab">Text classification</a>
+            <a href="#text-classification-tab">$i18n.getText('condec.label.text.classification')</a>
         </li>
         <li class="menu-item" id="menu-item-link-recommendation">
 			<a href="#link-recommendation-tab">$i18n.getText('condec.link.recommendation')</a>
@@ -71,6 +71,7 @@ $webResourceManager.requireResource("de.uhd.ifi.se.decision.management.jira:deci
         #parse("templates/tabs/chronology.vm")
     </div>
     <div class="tabs-pane" id="quality-check-tab">
+        #set ($viewIdentifier = "jira-issue-module")
         #parse("templates/tabs/qualityCheck.vm")
     </div>
     <div class="tabs-pane" id="text-classification-tab">

--- a/src/main/resources/templates/prompts/decisionGuidancePrompt.vm
+++ b/src/main/resources/templates/prompts/decisionGuidancePrompt.vm
@@ -16,16 +16,8 @@
         </table>
     </div>
 
-    ##<table id="recommendation-container-short" class="aui aui-table-list">
-    ##	<thead>
-    ##		<tr>
-    ##			<th>Recommendation</th>
-    ##			<th class="aui-table-column-issue-key">$i18n.getText("condec.recommendation.score")</th>
-    ##			<th class="aui-table-column-unsortable">$i18n.getText("condec.recommendation.manage")</th>
-    ##		</tr>
-    ##	</thead>
-    ##	<tbody id="quick-recommendations-table-body">
-    ##	</tbody>
-    ##</table>
-    ##<a href="#recommendation-container" style="width:100%" id="more-recommendations" class="aui-button-link">More</a>
+    <button id="go-to-decision-guidance-tab" class="aui-button aui-button-link">
+        <span class="aui-icon aui-icon-small aui-iconfont-link">Go to decision guidance tab</span>
+        Go to decision guidance tab
+    </button>
 </div>

--- a/src/main/resources/templates/prompts/definitionOfDoneCheckingPrompt.vm
+++ b/src/main/resources/templates/prompts/definitionOfDoneCheckingPrompt.vm
@@ -12,20 +12,10 @@
         This element is currently covered by <label id="condec-prompt-issue-coverage"></label> issues and <label
         id="condec-prompt-decision-coverage"></label> decisions.
 
-
-        ##        <div class="text-field" id="quality-check-issue-text-$viewIdentifier">
-        ##        </div>
-        ##        <div class="text-field" id="quality-check-decision-text-$viewIdentifier">
-        ##        </div>
-        ##        <div class="text-field" id="quality-check-knowledge-complete-text-$viewIdentifier">
-        ##        </div>
     </div>
+    <button id="go-to-quality-check-tab" class="aui-button aui-button-link">
+        <span class="aui-icon aui-icon-small aui-iconfont-link">Go to quality check tab</span>
+        Go to quality check tab
+    </button>
 
-    ##    <a href="#menu-item-quality-check-jira-issue-module"
-    ##       onclick="javascript:AJS.tabs.change(jQuery('a[href=&quot;#quality-check-tab&quot;]'));" style="width:100%"
-    ##       class="aui-button-link">View Violated Definition of Done Criteria</a><br/>
-    ##	<button id="definition-of-done-checking-prompt-button" class="aui-button aui-button-link">
-    ##		<span class="aui-icon aui-icon-small aui-iconfont-check">Confirm quality</span>
-    ##		I confirm that the definition of done is fulfilled.
-    ##	</button>
 </div>

--- a/src/main/resources/templates/prompts/linkRecommendationPrompt.vm
+++ b/src/main/resources/templates/prompts/linkRecommendationPrompt.vm
@@ -8,10 +8,10 @@
         <li><strong id="link-recommendation-prompt-num-duplicate-recommendations">0</strong> possible duplicates</li>
     </ul>
     Please check that the links of this knowledge element are complete and that there are no duplicates.<br/>
-    ##	<button id="link-recommendation-prompt-button" class="aui-button aui-button-link">
-    ##		<span class="aui-icon aui-icon-small aui-iconfont-check">Confirm quality</span>
-    ##		I confirm the high documentation quality!
-    ##	</button>
-    <a href="#related-knowledge-elements-tab" style="width:100%" class="aui-button-link">View Link and Duplicate
-        Recommendation</a>
+
+    <button id="go-to-link-recomendation-tab" class="aui-button aui-button-link">
+        <span class="aui-icon aui-icon-small aui-iconfont-link">Go to link recommendation tab</span>
+        Go to link recommendation tab
+    </button>
+
 </div>

--- a/src/main/resources/templates/prompts/nonValidatedElementsPrompt.vm
+++ b/src/main/resources/templates/prompts/nonValidatedElementsPrompt.vm
@@ -14,8 +14,12 @@
         <tbody id="non-validated-table-body">
         </tbody>
     </table>
-    <button id="non-validated-elements-validate-button" class="aui-button aui-button-link">
+    <button id="non-validated-elements-validate-button" class="aui-button aui-button-primary">
         <span class="aui-icon aui-icon-small aui-iconfont-check"></span>
         Validate all of these elements!
+    </button>
+    <button id="non-validated-elements-go-to-classification-tab" class="aui-button aui-button-link">
+        <span class="aui-icon aui-icon-small aui-iconfont-link">Go to text classification tab</span>
+        Go to text classification tab
     </button>
 </div>

--- a/src/main/resources/templates/prompts/nonValidatedElementsPrompt.vm
+++ b/src/main/resources/templates/prompts/nonValidatedElementsPrompt.vm
@@ -18,7 +18,7 @@
         <span class="aui-icon aui-icon-small aui-iconfont-check"></span>
         Validate all of these elements!
     </button>
-    <button id="non-validated-elements-go-to-classification-tab" class="aui-button aui-button-link">
+    <button id="go-to-classification-tab" class="aui-button aui-button-link">
         <span class="aui-icon aui-icon-small aui-iconfont-link">Go to text classification tab</span>
         Go to text classification tab
     </button>

--- a/src/main/resources/templates/prompts/unifiedPrompt.vm
+++ b/src/main/resources/templates/prompts/unifiedPrompt.vm
@@ -16,18 +16,25 @@
         <br/>
         <div id="non-validated-elements-prompt" class="condec-prompt">
             #parse("templates/prompts/nonValidatedElementsPrompt.vm")
+            <aui-spinner id="non-validated-spinner"></aui-spinner>
+
         </div>
         <br/>
         <div id="link-recommendation-prompt" class="condec-prompt">
             #parse("templates/prompts/linkRecommendationPrompt.vm")
+            <aui-spinner id="link-recommendation-spinner"></aui-spinner>
         </div>
         <br/>
         <div id="definition-of-done-prompt" class="condec-prompt">
             #parse("templates/prompts/definitionOfDoneCheckingPrompt.vm")
+            <aui-spinner id="dod-spinner"></aui-spinner>
+
         </div>
         <br/>
         <div id="decision-guidance-prompt" class="condec-prompt">
             #parse("templates/prompts/decisionGuidancePrompt.vm")
+            <aui-spinner id="decision-guidance-spinner"></aui-spinner>
+
         </div>
     </div>
     <footer class="aui-dialog2-footer">

--- a/src/main/resources/templates/prompts/unifiedPrompt.vm
+++ b/src/main/resources/templates/prompts/unifiedPrompt.vm
@@ -32,9 +32,7 @@
     </div>
     <footer class="aui-dialog2-footer">
         <div class="aui-dialog2-footer-actions">
-            <button id="warning-dialog-continue" class="aui-button">Continue anyway</button>
-            <button id="warning-dialog-fix-elements" class="aui-button aui-button-primary">Go back and fix</button>
-
+            <button id="warning-dialog-continue" class="aui-button">$i18n.getText('condec.button.continue')</button>
         </div>
     </footer>
 </section>


### PR DESCRIPTION
In this PR, the unified prompt is updated so that it only has one button (continue).

- [x] Also, links to each tab are added, which, when clicked, open the respective tab in a new browser tab
- [x] ~~When an action is performed (like validate all elements) from the prompt, the issues should be reloaded~~ The validate button is removed
- [x] Each element of the prompt also gets a spinner so that you can tell if it is done loading or not