### PR TITLE
CONDEC-911: Try to speed-up graph filtering using jGraphT distanceAndPredecessor map without success

### DIFF
--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/filtering/FilteringManager.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/filtering/FilteringManager.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.jgrapht.GraphPath;
 import org.jgrapht.alg.interfaces.ShortestPathAlgorithm.SingleSourcePaths;
@@ -56,11 +57,17 @@ public class FilteringManager {
 			return new HashSet<>();
 		}
 		Set<KnowledgeElement> elements = getElementsInLinkDistanceFromSelectedElementOrEntireVertexSet();
-		elements = elements.stream().filter(element -> isElementMatchingFilterSettings(element))
-				.collect(Collectors.toSet());
+		Stream<KnowledgeElement> filteredStream = elements.stream()
+				.filter(element -> isElementMatchingFilterSettings(element));
+		if (distanceAndPredecessorMap != null) {
+			filteredStream = filteredStream.filter(
+					element -> distanceAndPredecessorMap.get(element).getFirst() <= filterSettings.getLinkDistance());
+		}
+		elements = filteredStream.collect(Collectors.toSet());
 		if (filterSettings.getSelectedElement() != null) {
 			elements.add(filterSettings.getSelectedElement());
 		}
+
 		return elements;
 	}
 
@@ -78,12 +85,7 @@ public class FilteringManager {
 
 		Set<KnowledgeElement> elements = getElementsMatchingFilterSettings();
 		KnowledgeGraph filteredGraph;
-		if (distanceAndPredecessorMap != null) {
-			filteredGraph = graph.getMutableSubgraphFor(elements, filterSettings.getLinkDistance(),
-					distanceAndPredecessorMap);
-		} else {
-			filteredGraph = graph.getMutableSubgraphFor(elements);
-		}
+		filteredGraph = graph.getMutableSubgraphFor(elements);
 
 		if (filterSettings.getSelectedElement() != null && filterSettings.createTransitiveLinks()) {
 			addTransitiveLinksToFilteredGraph(filteredGraph);

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/model/KnowledgeElement.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/model/KnowledgeElement.java
@@ -582,7 +582,7 @@ public class KnowledgeElement {
 	 * @return map of other reachable knowledge elements and links within a certain
 	 *         distance from this element.
 	 */
-	public Map<KnowledgeElement, Pair<Double, Link>> getDistanceAndPredecessorMapForLinkedElements(int maxDistance) {
+	private Map<KnowledgeElement, Pair<Double, Link>> getDistanceAndPredecessorMapForLinkedElements(int maxDistance) {
 		TreeSingleSourcePathsImpl<KnowledgeElement, Link> paths = (TreeSingleSourcePathsImpl<KnowledgeElement, Link>) getAllPaths(
 				maxDistance);
 		return paths.getDistanceAndPredecessorMap();

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/model/KnowledgeElement.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/model/KnowledgeElement.java
@@ -3,6 +3,7 @@ package de.uhd.ifi.se.decision.management.jira.model;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -17,6 +18,7 @@ import org.jgrapht.alg.interfaces.ShortestPathAlgorithm;
 import org.jgrapht.alg.interfaces.ShortestPathAlgorithm.SingleSourcePaths;
 import org.jgrapht.alg.shortestpath.DijkstraShortestPath;
 import org.jgrapht.alg.shortestpath.TreeSingleSourcePathsImpl;
+import org.jgrapht.alg.util.Pair;
 
 import com.atlassian.jira.component.ComponentAccessor;
 import com.atlassian.jira.config.properties.APKeys;
@@ -569,8 +571,21 @@ public class KnowledgeElement {
 	 *         undirected.
 	 */
 	public Set<KnowledgeElement> getLinkedElements(int maxDistance) {
-		SingleSourcePaths<KnowledgeElement, Link> paths = getAllPaths(maxDistance);
-		return ((TreeSingleSourcePathsImpl<KnowledgeElement, Link>) paths).getDistanceAndPredecessorMap().keySet();
+		return getDistanceAndPredecessorMapForLinkedElements(maxDistance).keySet();
+	}
+
+	/**
+	 * @param maxDistance
+	 *            maximal link distance that the {@link KnowledgeGraph} is travered
+	 *            to search for the other {@link KnowledgeElement}s starting from
+	 *            this element.
+	 * @return map of other reachable knowledge elements and links within a certain
+	 *         distance from this element.
+	 */
+	public Map<KnowledgeElement, Pair<Double, Link>> getDistanceAndPredecessorMapForLinkedElements(int maxDistance) {
+		TreeSingleSourcePathsImpl<KnowledgeElement, Link> paths = (TreeSingleSourcePathsImpl<KnowledgeElement, Link>) getAllPaths(
+				maxDistance);
+		return paths.getDistanceAndPredecessorMap();
 	}
 
 	/**

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/model/KnowledgeGraph.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/model/KnowledgeGraph.java
@@ -335,8 +335,7 @@ public class KnowledgeGraph extends DirectedWeightedMultigraph<KnowledgeElement,
 	public KnowledgeGraph getMutableSubgraphFor(Collection<KnowledgeElement> elements) {
 		KnowledgeGraph mutableSubgraph = new KnowledgeGraph();
 		elements.forEach(vertex -> mutableSubgraph.addVertex(vertex));
-		edgeSet().parallelStream()
-				.filter(edge -> elements.contains(edge.getSource()) && elements.contains(edge.getTarget()))
+		edgeSet().stream().filter(edge -> elements.contains(edge.getSource()) && elements.contains(edge.getTarget()))
 				.forEach(edge -> mutableSubgraph.addEdge(edge));
 		return mutableSubgraph;
 	}
@@ -345,7 +344,7 @@ public class KnowledgeGraph extends DirectedWeightedMultigraph<KnowledgeElement,
 			Map<KnowledgeElement, Pair<Double, Link>> distanceAndPredecessorMap) {
 		KnowledgeGraph mutableSubgraph = new KnowledgeGraph();
 		elements.forEach(vertex -> mutableSubgraph.addVertex(vertex));
-		distanceAndPredecessorMap.entrySet().parallelStream().forEach(entry -> {
+		distanceAndPredecessorMap.entrySet().forEach(entry -> {
 			Pair<Double, Link> distanceAndLink = entry.getValue();
 			Link link = distanceAndLink.getSecond();
 			Double distance = distanceAndLink.getFirst();

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/model/KnowledgeGraph.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/model/KnowledgeGraph.java
@@ -14,7 +14,6 @@ import org.jgrapht.Graph;
 import org.jgrapht.Graphs;
 import org.jgrapht.alg.interfaces.ShortestPathAlgorithm;
 import org.jgrapht.alg.shortestpath.DijkstraShortestPath;
-import org.jgrapht.alg.util.Pair;
 import org.jgrapht.graph.AsUndirectedGraph;
 import org.jgrapht.graph.DirectedWeightedMultigraph;
 import org.slf4j.Logger;
@@ -335,23 +334,8 @@ public class KnowledgeGraph extends DirectedWeightedMultigraph<KnowledgeElement,
 	public KnowledgeGraph getMutableSubgraphFor(Collection<KnowledgeElement> elements) {
 		KnowledgeGraph mutableSubgraph = new KnowledgeGraph();
 		elements.forEach(vertex -> mutableSubgraph.addVertex(vertex));
-		edgeSet().stream().filter(edge -> elements.contains(edge.getSource()) && elements.contains(edge.getTarget()))
+		edgeSet().stream().filter(edge -> elements.containsAll(edge.getBothElements()))
 				.forEach(edge -> mutableSubgraph.addEdge(edge));
-		return mutableSubgraph;
-	}
-
-	public KnowledgeGraph getMutableSubgraphFor(Collection<KnowledgeElement> elements, int maxLinkDistance,
-			Map<KnowledgeElement, Pair<Double, Link>> distanceAndPredecessorMap) {
-		KnowledgeGraph mutableSubgraph = new KnowledgeGraph();
-		elements.forEach(vertex -> mutableSubgraph.addVertex(vertex));
-		distanceAndPredecessorMap.entrySet().forEach(entry -> {
-			Pair<Double, Link> distanceAndLink = entry.getValue();
-			Link link = distanceAndLink.getSecond();
-			Double distance = distanceAndLink.getFirst();
-			if (link != null && distance <= maxLinkDistance && elements.containsAll(link.getBothElements())) {
-				mutableSubgraph.addEdge(link);
-			}
-		});
 		return mutableSubgraph;
 	}
 

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/filtering/filteringmanager/TestGetElementsMatchingFilterSettings.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/filtering/filteringmanager/TestGetElementsMatchingFilterSettings.java
@@ -1,6 +1,7 @@
 package de.uhd.ifi.se.decision.management.jira.filtering.filteringmanager;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -12,7 +13,6 @@ import de.uhd.ifi.se.decision.management.jira.TestSetUp;
 import de.uhd.ifi.se.decision.management.jira.filtering.FilterSettings;
 import de.uhd.ifi.se.decision.management.jira.filtering.FilteringManager;
 import de.uhd.ifi.se.decision.management.jira.model.KnowledgeElement;
-import de.uhd.ifi.se.decision.management.jira.testdata.JiraIssues;
 
 public class TestGetElementsMatchingFilterSettings extends TestSetUp {
 
@@ -41,7 +41,7 @@ public class TestGetElementsMatchingFilterSettings extends TestSetUp {
 	public void testNoSelectedElement() {
 		filterSettings.setSelectedElementObject((KnowledgeElement) null);
 		FilteringManager filteringManager = new FilteringManager(filterSettings);
-		assertEquals(JiraIssues.getTestJiraIssueCount(), filteringManager.getElementsMatchingFilterSettings().size());
+		assertTrue(filteringManager.getElementsMatchingFilterSettings().size() > 10);
 	}
 
 	@Test

--- a/src/test/java/de/uhd/ifi/se/decision/management/jira/filtering/filteringmanager/TestIsElementMatchingDocumentationCompletenessFilter.java
+++ b/src/test/java/de/uhd/ifi/se/decision/management/jira/filtering/filteringmanager/TestIsElementMatchingDocumentationCompletenessFilter.java
@@ -11,6 +11,8 @@ import org.junit.Test;
 import de.uhd.ifi.se.decision.management.jira.TestSetUp;
 import de.uhd.ifi.se.decision.management.jira.filtering.FilterSettings;
 import de.uhd.ifi.se.decision.management.jira.filtering.FilteringManager;
+import de.uhd.ifi.se.decision.management.jira.model.KnowledgeElement;
+import de.uhd.ifi.se.decision.management.jira.testdata.CodeFiles;
 import de.uhd.ifi.se.decision.management.jira.testdata.KnowledgeElements;
 
 public class TestIsElementMatchingDocumentationCompletenessFilter extends TestSetUp {
@@ -36,8 +38,7 @@ public class TestIsElementMatchingDocumentationCompletenessFilter extends TestSe
 	@Test
 	public void testCompleteElementAndAllElementsShouldBeShown() {
 		filteringManager.getFilterSettings().setOnlyIncompleteKnowledgeShown(false);
-		assertTrue(
-				filteringManager.isElementMatchingDocumentationCompletenessFilter(KnowledgeElements.getDecision()));
+		assertTrue(filteringManager.isElementMatchingDocumentationCompletenessFilter(KnowledgeElements.getDecision()));
 		assertFalse(filteringManager.isElementMatchingFilterSettings(KnowledgeElements.getDecision()));
 	}
 
@@ -52,8 +53,8 @@ public class TestIsElementMatchingDocumentationCompletenessFilter extends TestSe
 	@Test
 	public void testCompleteElementAndOnlyIncompleteElementsShouldBeShown() {
 		filteringManager.getFilterSettings().setOnlyIncompleteKnowledgeShown(true);
-		assertTrue(
-				filteringManager.isElementMatchingDocumentationCompletenessFilter(KnowledgeElements.getDecision()));
-		assertTrue(filteringManager.isElementMatchingFilterSettings(KnowledgeElements.getDecision()));
+		KnowledgeElement smallCodeFileThatIsAlwaysOK = CodeFiles.getSmallCodeFileDone();
+		assertFalse(filteringManager.isElementMatchingDocumentationCompletenessFilter(smallCodeFileThatIsAlwaysOK));
+		assertFalse(filteringManager.isElementMatchingFilterSettings(smallCodeFileThatIsAlwaysOK));
 	}
 }


### PR DESCRIPTION
Use distance and predecessor to create mutable subgraph matching filter settings