### PR TITLE
Condec 1018.fix.decision.guidance.recommendation.icons

### DIFF
--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/recommendation/decisionguidance/KnowledgeSource.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/recommendation/decisionguidance/KnowledgeSource.java
@@ -6,6 +6,7 @@ import de.uhd.ifi.se.decision.management.jira.recommendation.decisionguidance.pr
 import de.uhd.ifi.se.decision.management.jira.recommendation.decisionguidance.rdfsource.RDFSource;
 import org.codehaus.jackson.annotate.JsonSubTypes;
 import org.codehaus.jackson.annotate.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 /**
  * Contains basic data to identify a knowledge source. Knowledge sources can be
@@ -19,7 +20,7 @@ import org.codehaus.jackson.annotate.JsonTypeInfo;
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "className")
 @JsonSubTypes({@JsonSubTypes.Type(value = RDFSource.class, name = "RDFSource"), @JsonSubTypes.Type(value = ProjectSource.class, name = "ProjectSource")})
-@com.fasterxml.jackson.annotation.JsonIgnore({"icon"})
+@JsonIgnoreProperties({"icon"})
 public abstract class KnowledgeSource {
 
 	/**

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/recommendation/decisionguidance/KnowledgeSource.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/recommendation/decisionguidance/KnowledgeSource.java
@@ -4,7 +4,6 @@ import javax.xml.bind.annotation.XmlElement;
 
 import de.uhd.ifi.se.decision.management.jira.recommendation.decisionguidance.projectsource.ProjectSource;
 import de.uhd.ifi.se.decision.management.jira.recommendation.decisionguidance.rdfsource.RDFSource;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.codehaus.jackson.annotate.JsonSubTypes;
 import org.codehaus.jackson.annotate.JsonTypeInfo;
 
@@ -20,7 +19,7 @@ import org.codehaus.jackson.annotate.JsonTypeInfo;
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "className")
 @JsonSubTypes({@JsonSubTypes.Type(value = RDFSource.class, name = "RDFSource"), @JsonSubTypes.Type(value = ProjectSource.class, name = "ProjectSource")})
-@JsonIgnoreProperties({"icon"})
+@com.fasterxml.jackson.annotation.JsonIgnore({"icon"})
 public abstract class KnowledgeSource {
 
 	/**


### PR DESCRIPTION
Fix [CONDEC-1018](https://jira-se.ifi.uni-heidelberg.de/browse/CONDEC-1018) by changing the `JsonIgnore` annotation from `import org.codehaus.jackson.annotate.JsonIgnoreProperties;` to `import com.fasterxml.jackson.annotation.JsonIgnoreProperties;`, which resolves the conflic with the `XmlElement` annotation, i.e. activates the serialization of the icon attribute, but keeps the deserialization deactivated.