### PR TITLE
CONDEC-1023: Fix bug manage discard not possible with arguments

### DIFF
--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/recommendation/decisionguidance/ElementRecommendation.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/recommendation/decisionguidance/ElementRecommendation.java
@@ -46,6 +46,7 @@ public class ElementRecommendation extends KnowledgeElement implements Recommend
 	/**
 	 * Pro and Con {@link Argument}s for the recommendation.
 	 */
+	@JsonIgnore
 	private List<Argument> arguments;
 
 	/**

--- a/src/main/java/de/uhd/ifi/se/decision/management/jira/recommendation/decisionguidance/ElementRecommendation.java
+++ b/src/main/java/de/uhd/ifi/se/decision/management/jira/recommendation/decisionguidance/ElementRecommendation.java
@@ -46,7 +46,6 @@ public class ElementRecommendation extends KnowledgeElement implements Recommend
 	/**
 	 * Pro and Con {@link Argument}s for the recommendation.
 	 */
-	@JsonIgnore
 	private List<Argument> arguments;
 
 	/**

--- a/src/main/resources/js/recommendation/condec.decision.guidance.api.js
+++ b/src/main/resources/js/recommendation/condec.decision.guidance.api.js
@@ -218,7 +218,8 @@
      */
     ConDecDecisionGuidanceAPI.prototype.undoDiscardRecommendation = function(recommendation) {
         recommendation.isDiscarded = false;
-        recommendation.arguments = [];  // Arguments of discarded recommendations are ignored as they are not stored
+        recommendation.arguments = [];  // Arguments of discarded recommendations are ignored as
+        //                                 they are not stored
         return generalApi.postJSONReturnPromise(`${this.restPrefix}` +
             `/undo-discard/${conDecAPI.projectKey}`, recommendation);
     };

--- a/src/main/resources/js/recommendation/condec.decision.guidance.api.js
+++ b/src/main/resources/js/recommendation/condec.decision.guidance.api.js
@@ -204,6 +204,7 @@
      */
     ConDecDecisionGuidanceAPI.prototype.discardRecommendation = function(recommendation) {
         recommendation.isDiscarded = true;
+        recommendation.arguments = [];  // Ignore arguments when discarding
         return generalApi.postJSONReturnPromise(`${this.restPrefix}` +
             `/discard/${conDecAPI.projectKey}`, recommendation);
     };
@@ -217,6 +218,7 @@
      */
     ConDecDecisionGuidanceAPI.prototype.undoDiscardRecommendation = function(recommendation) {
         recommendation.isDiscarded = false;
+        recommendation.arguments = [];  // Arguments of discarded recommendations are ignored as they are not stored
         return generalApi.postJSONReturnPromise(`${this.restPrefix}` +
             `/undo-discard/${conDecAPI.projectKey}`, recommendation);
     };

--- a/src/main/resources/js/recommendation/condec.decision.guidance.js
+++ b/src/main/resources/js/recommendation/condec.decision.guidance.js
@@ -69,6 +69,7 @@
             counter++;
             let tableRow;
             if (recommendation.isDiscarded) {
+                recommendation.arguments = [];  // Ignore arguments of discarded recommendations
                 tableRow = "<tr class = \"discarded\">";
             } else {
                 tableRow = "<tr>";


### PR DESCRIPTION
As recommendations are discarded by their text contents, i.e. summary, only (see [this decision](https://jira-se.ifi.uni-heidelberg.de/browse/CONDEC-990?focusedCommentId=108600&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-108600)), their arguments can be ignored. This resolves the deserialization issues causing the bug